### PR TITLE
Add Codecoverage and report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,7 @@ jobs:
       run: mage build
 
     - name: Test
-      run: mage test
+      run: mage CITest
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       run: mage CITest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3

--- a/magefile.go
+++ b/magefile.go
@@ -69,6 +69,7 @@ func runCITests(extraTestArgs ...string) error {
 	if mg.Verbose() {
 		args = append(args, "-v")
 	}
+    args = append(args, "-race")
 	args = append(args, "-tags=jwx_es256k")
 	args = append(args, "-covermode=atomic")
 	args = append(args, "-coverprofile=coverage.out")

--- a/magefile.go
+++ b/magefile.go
@@ -69,7 +69,6 @@ func runCITests(extraTestArgs ...string) error {
 	if mg.Verbose() {
 		args = append(args, "-v")
 	}
-    args = append(args, "-race")
 	args = append(args, "-tags=jwx_es256k")
 	args = append(args, "-covermode=atomic")
 	args = append(args, "-coverprofile=coverage.out")

--- a/magefile.go
+++ b/magefile.go
@@ -34,7 +34,7 @@ func Build() error {
 // Clean deletes any build artifacts.
 func Clean() {
 	fmt.Println("Cleaning...")
-	_ = os.RemoveAll("bin")
+	os.RemoveAll("bin")
 }
 
 // Run the service via docker-compose
@@ -48,6 +48,12 @@ func Test() error {
 	return runTests()
 }
 
+// CITest runs unit tests with coverage as a part of CI.
+// The mage `-v` option will trigger a verbose output of the test
+func CITest() error {
+	return ciTests()
+}
+
 // Spec generates an OpenAPI spec yaml based on code annotations.
 func Spec() error {
 	swagCommand := "swag"
@@ -57,6 +63,27 @@ func Spec() error {
 	}
 	return sh.Run(swagCommand, "init", "-g", "cmd/main.go", "--pd", "-ot", "yaml")
 }
+
+func ciTests(extraTestArgs ...string) error {
+	args := []string{"test"}
+	if mg.Verbose() {
+		args = append(args, "-v")
+	}
+	args = append(args, "-tags=jwx_es256k")
+	args = append(args, "-covermode=atomic")
+	args = append(args, "-coverprofile=coverage.out")
+	args = append(args, extraTestArgs...)
+	args = append(args, "./...")
+	testEnv := map[string]string{
+		"CGO_ENABLED": "1",
+		"GO111MODULE": "on",
+	}
+	writer := ColorizeTestStdout()
+	fmt.Printf("%+v", args)
+	_, err := sh.Exec(testEnv, writer, os.Stderr, Go, args...)
+	return err
+}
+
 
 func runTests(extraTestArgs ...string) error {
 	args := []string{"test"}

--- a/magefile.go
+++ b/magefile.go
@@ -51,7 +51,7 @@ func Test() error {
 // CITest runs unit tests with coverage as a part of CI.
 // The mage `-v` option will trigger a verbose output of the test
 func CITest() error {
-	return ciTests()
+	return runCITests()
 }
 
 // Spec generates an OpenAPI spec yaml based on code annotations.
@@ -64,7 +64,7 @@ func Spec() error {
 	return sh.Run(swagCommand, "init", "-g", "cmd/main.go", "--pd", "-ot", "yaml")
 }
 
-func ciTests(extraTestArgs ...string) error {
+func runCITests(extraTestArgs ...string) error {
 	args := []string{"test"}
 	if mg.Verbose() {
 		args = append(args, "-v")


### PR DESCRIPTION
Addresses #64 

Added code coverage and simple report.

Followed https://about.codecov.io/blog/getting-started-with-code-coverage-for-golang/