### PR TITLE
Update README sections on default ports (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You should then be able to send requests as follows:
 Note: port 3000 is used by default, specified in `config.toml`, for the SSI Service process. If you're running via `mage run` or docker compose, the port to access will be `8080`.
 
 ```shell
- ~ curl localhost:8080/health
+ ~ curl localhost:3000/health
 {"status":"OK"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ cd build && docker-compose up
 
 You should then be able to send requests as follows:
 
-Note: port 3000 is used by default. If you're running via docker compose, the port will be `8000`.
+Note: port 3000 is used by default, specified in `config.toml`, for the SSI Service process. If you're running via `mage run` or docker compose, the port to access will be `8080`.
 
 ```shell
- ~ curl localhost:3000/health
+ ~ curl localhost:8080/health
 {"status":"OK"}
 ```
 


### PR DESCRIPTION
Checking if this is a simple docs fix?

In the [`README`](https://github.com/TBD54566975/ssi-service/blob/main/README.md?plain=1#L74):

```
Note: port 3000 is used by default. If you're running via docker compose, the port will be `8000`.
```

I'm seeing that whether I run as `mage run` or `docker compose up`, I get bound on `8080`; neither `3000` nor `8000`.

I think this is because [`mage run`](https://github.com/TBD54566975/ssi-service/blob/main/magefile.go#L42) in turn calls Docker Compose?

```
// Run the service via docker-compose
func Run() error {
	return sh.Run("docker-compose", "--project-directory", "build", "up")
}
```

Proposed PR to update docs if this is the case.