### PR TITLE
Improvements to magefile Docker handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mage run
 Or, you can run docker-compose yourself:
 
 ```shell
-cd build && docker-compose up 
+cd build && docker-compose up --build
 ```
 
 ### Health and Readiness Checks


### PR DESCRIPTION
Ideally the new contributor experience for developers on any platform is:

- Install Go and Mage
- `mage run`
- Success! :rocket:

To that end, this PR proposes three improvements to the existing project [magefile](https://github.com/TBD54566975/ssi-service/blob/7390058ce0c41276b1ddc12874a0c7024c49b69d/magefile.go):

1. Automatically rebuild the containers every time `mage run` is executed to ensure local code changes are picked up.
2. Add a mage target `CleanRun` that stops and removes artifacts created by Docker Compose (containers, networks, and images).
3. Add a check to ensure the Docker engine is running before attempting to execute `docker-compose` commands.

## 1. Build/Rebuild containers on every mage run

### Rationale

If, after running `mage run` for the first time, a user makes any code modifications and runs either of the following commands:

- `mage run`
- `mage cbt && mage run`

they will discover that their modifications had no impact on the redeployed SSI Service.  This could lead to confusion and a poor experience.

### Proposed Improvement

Rather than adding complexity to onboarding by requiring users to run a different mage command to rebuild the Docker containers after code changes, make the default `mage run` target handle both initial and re-deploys by adding the `--build` argument to the `docker-compose` command.

Before:
```go
sh.Run("docker-compose", "--project-directory", "build", "up")
```
After:
```go
sh.Run("docker-compose", "--project-directory", "build", "up", "--build")
```

On the first run, there is no difference between Docker Compose `up` and `up --build` since the container images don't exist on the local machine and have to be built/downloaded.  On subsequent runs:

- If no local changes occurred, the second `up --build` call will only take ~1-2 seconds longer to complete.
- If local changes _were_ made, the addition of the `--build` argument will ensure that the rebuilt containers incorporate the modifications and the user experience will match expectations.

On a related note, the [README](https://github.com/TBD54566975/ssi-service/blob/7390058ce0c41276b1ddc12874a0c7024c49b69d/README.md) was updated to include the `--build` argument for those that prefer to execute `docker-compose` commands directly.

## 2. Add a Docker clean mage target

### Rationale

While the revised `mage run` target will pick up local code changes and rebuild the container images, there are infrequent scenarios where it is necessary to completely remove the containers, networks, and images created by Docker Compose.  Contributors might not be sufficiently skilled at interacting with Docker to spot the symptoms and take the appropriate steps.

### Proposed Improvement

Add  `mage cleanRun` that can be suggested to contributors experiencing issues to quickly rule out local Docker corruption.

## 3. Check that Docker is running

### Rationale

If a user runs `mage run` or `mage cleanRun` without first starting the Docker engine on their location workstation, they encounter a verbose and confusing message similar to the following:

```shell
$ mage run
Traceback (most recent call last):
  File "docker/api/client.py", line 268, in _raise_for_status
  File "requests/models.py", line 941, in raise_for_status
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/version

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "docker/api/client.py", line 214, in _retrieve_server_version
  File "docker/api/daemon.py", line 181, in version
  File "docker/api/client.py", line 274, in _result
  File "docker/api/client.py", line 270, in _raise_for_status
  File "docker/errors.py", line 31, in create_api_error_from_http_exception
docker.errors.APIError: 500 Server Error for http+docker://localhost/version: Internal Server Error ("b'dial unix docker.raw.sock: connect: no such file or directory'")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 81, in main
  File "compose/cli/main.py", line 200, in perform_command
  File "compose/cli/command.py", line 60, in project_from_options
  File "compose/cli/command.py", line 152, in get_project
  File "compose/cli/docker_client.py", line 41, in get_client
  File "compose/cli/docker_client.py", line 170, in docker_client
  File "docker/api/client.py", line 197, in __init__
  File "docker/api/client.py", line 221, in _retrieve_server_version
docker.errors.DockerException: Error while fetching server API version: 500 Server Error for http+docker://localhost/version: Internal Server Error ("b'dial unix docker.raw.sock: connect: no such file or directory'")
[12945] Failed to execute script docker-compose
Error: running "docker-compose --project-directory build up" failed with exit code 255
```

This could lead the user to assume there is an issue with the SSI Service.

### Proposed Improvement

Before executing `docker` or `docker-compose` commands check `isDockerReady()`, and if not, the interpretability of the error message is significantly improved:

```shell
❯ mage run
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Error: could not run docker: running "docker ps" failed with exit code 1
```
