### PR TITLE
Add context to error responses returned to client

### DIFF
--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -81,7 +81,7 @@ func (cr CredentialRouter) CreateCredential(ctx context.Context, w http.Response
     if err := framework.Decode(r, &request); err != nil {
         errMsg := "invalid create credential request"
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
     }
 
     req := request.ToServiceRequest()
@@ -89,7 +89,7 @@ func (cr CredentialRouter) CreateCredential(ctx context.Context, w http.Response
     if err != nil {
         errMsg := "could not create credential"
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
     }
 
     resp := CreateCredentialResponse{Credential: createCredentialResponse.Credential}
@@ -123,7 +123,7 @@ func (cr CredentialRouter) GetCredential(ctx context.Context, w http.ResponseWri
     if err != nil {
         errMsg := fmt.Sprintf("could not get credential with id: %s", *id)
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
     }
 
     resp := GetCredentialResponse{
@@ -179,7 +179,7 @@ func (cr CredentialRouter) getCredentialsByIssuer(issuer string, ctx context.Con
     if err != nil {
         errMsg := fmt.Sprintf("could not get credentials for issuer: %s", util.SanitizeLog(issuer))
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
     }
 
     resp := GetCredentialsResponse{Credentials: gotCredentials.Credentials}
@@ -191,7 +191,7 @@ func (cr CredentialRouter) getCredentialsBySubject(subject string, ctx context.C
     if err != nil {
         errMsg := fmt.Sprintf("could not get credentials for subject: %s", util.SanitizeLog(subject))
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
     }
 
     resp := GetCredentialsResponse{Credentials: gotCredentials.Credentials}
@@ -203,7 +203,7 @@ func (cr CredentialRouter) getCredentialsBySchema(schema string, ctx context.Con
     if err != nil {
         errMsg := fmt.Sprintf("could not get credentials for schema: %s", util.SanitizeLog(schema))
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
     }
 
     resp := GetCredentialsResponse{Credentials: gotCredentials.Credentials}
@@ -232,7 +232,7 @@ func (cr CredentialRouter) DeleteCredential(ctx context.Context, w http.Response
     if err := cr.service.DeleteCredential(credential.DeleteCredentialRequest{ID: *id}); err != nil {
         errMsg := fmt.Sprintf("could not delete credential with id: %s", *id)
         logrus.WithError(err).Error(errMsg)
-        return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+        return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
     }
 
     return framework.Respond(ctx, w, nil, http.StatusOK)

--- a/pkg/server/router/did.go
+++ b/pkg/server/router/did.go
@@ -90,7 +90,7 @@ func (dr DIDRouter) CreateDIDByMethod(ctx context.Context, w http.ResponseWriter
 	if err := framework.Decode(r, &request); err != nil {
 		errMsg := "invalid create DID request"
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	// TODO(gabe) check if the key type is supported for the method, to tell whether this is a bad req or internal error
@@ -99,7 +99,7 @@ func (dr DIDRouter) CreateDIDByMethod(ctx context.Context, w http.ResponseWriter
 	if err != nil {
 		errMsg := fmt.Sprintf("could not create DID for method<%s> with key type: %s", *method, request.KeyType)
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
 	resp := CreateDIDByMethodResponse{
@@ -146,7 +146,7 @@ func (dr DIDRouter) GetDIDByMethod(ctx context.Context, w http.ResponseWriter, _
 	if err != nil {
 		errMsg := fmt.Sprintf("could not get DID for method<%s> with id: %s", *method, *id)
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	resp := GetDIDByMethodResponse{DID: gotDID.DID}

--- a/pkg/server/router/keystore.go
+++ b/pkg/server/router/keystore.go
@@ -66,20 +66,20 @@ func (ksr *KeyStoreRouter) StoreKey(ctx context.Context, w http.ResponseWriter, 
 	if err := framework.Decode(r, &request); err != nil {
 		errMsg := "invalid store key request"
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	req, err := request.ToServiceRequest()
 	if err != nil {
 		errMsg := "could not process store key request"
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	if err := ksr.service.StoreKey(*req); err != nil {
 		errMsg := fmt.Sprintf("could not store key: %s, %s", request.ID, err.Error())
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
 	return framework.Respond(ctx, w, nil, http.StatusCreated)
@@ -114,7 +114,7 @@ func (ksr *KeyStoreRouter) GetKeyDetails(ctx context.Context, w http.ResponseWri
 	if err != nil {
 		errMsg := fmt.Sprintf("could not get key details for id: %s", *id)
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	resp := GetKeyDetailsResponse{

--- a/pkg/server/router/schema.go
+++ b/pkg/server/router/schema.go
@@ -57,7 +57,7 @@ func (sr SchemaRouter) CreateSchema(ctx context.Context, w http.ResponseWriter, 
 	if err := framework.Decode(r, &request); err != nil {
 		errMsg := "invalid create schema request"
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	req := schema.CreateSchemaRequest{Author: request.Author, Name: request.Name, Schema: request.Schema}
@@ -65,7 +65,7 @@ func (sr SchemaRouter) CreateSchema(ctx context.Context, w http.ResponseWriter, 
 	if err != nil {
 		errMsg := fmt.Sprintf("could not create schema with authoring DID: %s", request.Author)
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
 	resp := CreateSchemaResponse{ID: createSchemaResponse.ID, Schema: createSchemaResponse.Schema}
@@ -90,7 +90,7 @@ func (sr SchemaRouter) GetSchemas(ctx context.Context, w http.ResponseWriter, r 
 	if err != nil {
 		errMsg := "could not get schemas"
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusInternalServerError)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 	resp := GetSchemasResponse{Schemas: gotSchemas.Schemas}
 	return framework.Respond(ctx, w, resp, http.StatusOK)
@@ -123,7 +123,7 @@ func (sr SchemaRouter) GetSchemaByID(ctx context.Context, w http.ResponseWriter,
 	if err != nil {
 		errMsg := fmt.Sprintf("could not get schema with id: %s", *id)
 		logrus.WithError(err).Error(errMsg)
-		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
 	}
 
 	resp := GetSchemaResponse{Schema: gotSchema.Schema}


### PR DESCRIPTION
This change preserves error context when sending error responses back to the client. It does so by using `framework.NewRequestError(err, httpCode)`` instead of `framework.NewRequestErrorMsg(errMsg, httpCode)` in places where the err object is available.

This fixes https://github.com/TBD54566975/ssi-service/issues/75