### PR TITLE
provide development builds as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install mage
       run: go install github.com/magefile/mage
 
-    - name: Build
+    - name: Build library
       run: mage build
 
     - name: Test
@@ -48,3 +48,12 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+    - name: Build binary
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: mage artifact
+
+    - uses: actions/upload-artifact@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        path: bin/ssi-service

--- a/magefile.go
+++ b/magefile.go
@@ -26,8 +26,14 @@ var (
 
 // Build builds the library.
 func Build() error {
-	fmt.Println("Building...")
+	fmt.Println("Building library...")
 	return sh.Run(Go, "build", "-tags", "jwx_es256k", "./...")
+}
+
+// Artifact builds the binary.
+func Artifact() error {
+	fmt.Println("Building binary...")
+	return sh.Run(Go, "build", "-tags", "jwx_es256k", "-o", "./bin/ssi-service", "./cmd")
 }
 
 // Vuln downloads and runs govulncheck https://go.dev/blog/vuln


### PR DESCRIPTION
Via upload of built binaries post validation

Downstream consumers of ssi-service may wish to use bleeding edge functionality
without having easy access to golang build tooling. By providing binaries as an
option users do not have to worry about development environment testing to
start working with ssi-service latest features / bug fixes
