### PR TITLE
have dwn go through the svc endpoint

### DIFF
--- a/pkg/server/router/dwn_test.go
+++ b/pkg/server/router/dwn_test.go
@@ -39,7 +39,9 @@ func TestDWNRouter(t *testing.T) {
 
 		serviceConfig := config.DWNServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "dwn"}}
 		keyStore := testKeyStoreService(t, bolt)
-		dwnService, err := dwn.NewDWNService(serviceConfig, bolt, keyStore)
+		credentialService := testCredentialService(t, bolt, keyStore)
+		manifestService := testManifestService(t, bolt, keyStore, credentialService)
+		dwnService, err := dwn.NewDWNService(serviceConfig, bolt, keyStore, manifestService)
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, dwnService)
 

--- a/pkg/server/router/testutils_test.go
+++ b/pkg/server/router/testutils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/pkg/service/credential"
 	"github.com/tbd54566975/ssi-service/pkg/service/keystore"
+	"github.com/tbd54566975/ssi-service/pkg/service/manifest"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
@@ -27,4 +28,13 @@ func testCredentialService(t *testing.T, db *storage.BoltDB, keyStore *keystore.
 	require.NoError(t, err)
 	require.NotEmpty(t, credentialService)
 	return credentialService
+}
+
+func testManifestService(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, credential *credential.Service) *manifest.Service {
+	serviceConfig := config.ManifestServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "manifest"}}
+	// create a manifest service
+	manifestService, err := manifest.NewManifestService(serviceConfig, db, keyStore, credential)
+	require.NoError(t, err)
+	require.NotEmpty(t, manifestService)
+	return manifestService
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,7 +104,7 @@ func TestDIDAPI(t *testing.T) {
 			_ = os.Remove(storage.DBFile)
 		})
 
-		_, keyStoreService := newKeyStore(tt, bolt)
+		_, keyStoreService := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStoreService)
 
 		// get DID methods
@@ -132,7 +132,7 @@ func TestDIDAPI(t *testing.T) {
 			_ = os.Remove(storage.DBFile)
 		})
 
-		_, keyStoreService := newKeyStore(tt, bolt)
+		_, keyStoreService := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStoreService)
 
 		// create DID by method - key - missing body
@@ -181,7 +181,7 @@ func TestDIDAPI(t *testing.T) {
 			_ = os.Remove(storage.DBFile)
 		})
 
-		_, keyStore := newKeyStore(tt, bolt)
+		_, keyStore := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStore)
 
 		// get DID by method
@@ -720,7 +720,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		// missing required field: Manifest
 		badManifestRequest := router.CreateManifestRequest{}
@@ -763,7 +763,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		w := httptest.NewRecorder()
 
@@ -820,7 +820,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		w := httptest.NewRecorder()
 
@@ -860,7 +860,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		// good request
 		createManifestRequest := getValidManifestRequest()
@@ -915,7 +915,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		// missing required field: Application
 		badManifestRequest := router.SubmitApplicationRequest{
@@ -975,7 +975,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 		w := httptest.NewRecorder()
 
 		// get a application that doesn't exit
@@ -1066,7 +1066,7 @@ func TestManifestAPI(t *testing.T) {
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestRouter := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, _ := testManifest(tt, bolt, keyStoreService, credentialService)
 
 		// good manifest request
 		createManifestRequest := getValidManifestRequest()
@@ -1140,9 +1140,9 @@ func TestDWNAPI(t *testing.T) {
 		})
 
 		keyStoreService := testKeyStoreService(tt, bolt)
-		dwnService := testDWNRouter(tt, bolt, keyStoreService)
 		credentialService := testCredentialService(tt, bolt, keyStoreService)
-		manifestService := testManifestRouter(tt, bolt, keyStoreService, credentialService)
+		manifestRouter, manifestService := testManifest(tt, bolt, keyStoreService, credentialService)
+		dwnService := testDWNRouter(tt, bolt, keyStoreService, manifestService)
 
 		w := httptest.NewRecorder()
 
@@ -1151,7 +1151,7 @@ func TestDWNAPI(t *testing.T) {
 
 		requestValue := newRequestValue(tt, createManifestRequest)
 		req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/manifests", requestValue)
-		err = manifestService.CreateManifest(newRequestContext(), w, req)
+		err = manifestRouter.CreateManifest(newRequestContext(), w, req)
 		assert.NoError(tt, err)
 
 		var resp router.CreateManifestResponse
@@ -1180,7 +1180,7 @@ func TestKeyStoreAPI(t *testing.T) {
 			_ = os.Remove(storage.DBFile)
 		})
 
-		keyStoreRouter, _ := newKeyStore(tt, bolt)
+		keyStoreRouter, _ := testKeyStore(tt, bolt)
 		w := httptest.NewRecorder()
 
 		// bad key type
@@ -1229,7 +1229,7 @@ func TestKeyStoreAPI(t *testing.T) {
 			_ = os.Remove(storage.DBFile)
 		})
 
-		keyStoreService, _ := newKeyStore(tt, bolt)
+		keyStoreService, _ := testKeyStore(tt, bolt)
 		w := httptest.NewRecorder()
 
 		// store a valid key
@@ -1367,7 +1367,7 @@ func getValidApplicationRequest(manifestID string, submissionDescriptorId string
 	return createApplicationRequest
 }
 
-func newKeyStore(t *testing.T, bolt *storage.BoltDB) (*router.KeyStoreRouter, *keystore.Service) {
+func testKeyStore(t *testing.T, bolt *storage.BoltDB) (*router.KeyStoreRouter, *keystore.Service) {
 	keyStoreService := testKeyStoreService(t, bolt)
 
 	// create router for service
@@ -1452,28 +1452,23 @@ func testCredentialRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore
 	return credentialRouter
 }
 
-func testManifestService(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, credential *credential.Service) *manifest.Service {
+func testManifest(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, credential *credential.Service) (*router.ManifestRouter, *manifest.Service) {
 	serviceConfig := config.ManifestServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "manifest"}}
 	// create a manifest service
 	manifestService, err := manifest.NewManifestService(serviceConfig, db, keyStore, credential)
 	require.NoError(t, err)
 	require.NotEmpty(t, manifestService)
-	return manifestService
-}
-
-func testManifestRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service, credential *credential.Service) *router.ManifestRouter {
-	manifestService := testManifestService(t, bolt, keyStore, credential)
 
 	// create router for service
 	manifestRouter, err := router.NewManifestRouter(manifestService)
 	require.NoError(t, err)
 	require.NotEmpty(t, manifestRouter)
 
-	return manifestRouter
+	return manifestRouter, manifestService
 }
 
-func testDWNRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service) *router.DWNRouter {
-	dwnService, err := dwn.NewDWNService(config.DWNServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "test-dwn"}, DWNEndpoint: "test-endpoint"}, bolt, keyStore)
+func testDWNRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service, manifest *manifest.Service) *router.DWNRouter {
+	dwnService, err := dwn.NewDWNService(config.DWNServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "test-dwn"}, DWNEndpoint: "test-endpoint"}, bolt, keyStore, manifest)
 	require.NoError(t, err)
 	require.NotEmpty(t, dwnService)
 

--- a/pkg/service/dwn/dwn.go
+++ b/pkg/service/dwn/dwn.go
@@ -3,22 +3,23 @@ package dwn
 import (
 	"fmt"
 
+	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/util"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
 	"github.com/tbd54566975/ssi-service/pkg/service/keystore"
-	manifeststorage "github.com/tbd54566975/ssi-service/pkg/service/manifest/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/manifest"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
 type Service struct {
-	config          config.DWNServiceConfig
-	manifestStorage manifeststorage.Storage
+	config config.DWNServiceConfig
 
 	// external dependencies
 	keyStore *keystore.Service
+	manifest *manifest.Service
 }
 
 func (s Service) Type() framework.Type {
@@ -26,13 +27,19 @@ func (s Service) Type() framework.Type {
 }
 
 func (s Service) Status() framework.Status {
-	if s.manifestStorage == nil {
+	err := sdkutil.NewAppendError()
+	if s.keyStore == nil {
+		err.AppendString("keystore not set")
+	}
+	if s.manifest == nil {
+		err.AppendString("manifest not set")
+	}
+	if gotErr := err.Error(); gotErr != nil {
 		return framework.Status{
 			Status:  framework.StatusNotReady,
-			Message: "no manifestStorage",
+			Message: gotErr.Error(),
 		}
 	}
-
 	return framework.Status{Status: framework.StatusReady}
 }
 
@@ -40,24 +47,25 @@ func (s Service) Config() config.DWNServiceConfig {
 	return s.config
 }
 
-func NewDWNService(config config.DWNServiceConfig, s storage.ServiceStorage, keyStore *keystore.Service) (*Service, error) {
-	manifestStorage, err := manifeststorage.NewManifestStorage(s)
-	if err != nil {
-		errMsg := "could not instantiate manifestStorage for the dwn service"
-		return nil, util.LoggingErrorMsg(err, errMsg)
+func NewDWNService(config config.DWNServiceConfig, s storage.ServiceStorage, keyStore *keystore.Service, manifest *manifest.Service) (*Service, error) {
+	if keyStore == nil {
+		return nil, fmt.Errorf("keystore not set")
 	}
-
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest not set")
+	}
 	return &Service{
-		config:          config,
-		manifestStorage: manifestStorage,
-		keyStore:        keyStore,
+		config:   config,
+		keyStore: keyStore,
+		manifest: manifest,
 	}, nil
 }
 
 func (s Service) GetManifest(request DWNPublishManifestRequest) (*DWNPublishManifestResponse, error) {
+
 	logrus.Debugf("getting manifest: %s", request.ManifestID)
 
-	gotManifest, err := s.manifestStorage.GetManifest(request.ManifestID)
+	gotManifest, err := s.manifest.GetManifest(manifest.GetManifestRequest{ID: request.ManifestID})
 	if err != nil {
 		errMsg := fmt.Sprintf("could not get manifest: %s", request.ManifestID)
 		return nil, util.LoggingErrorMsg(err, errMsg)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -99,7 +99,7 @@ func instantiateServices(config config.ServicesConfig) ([]framework.Service, err
 		return nil, util.LoggingErrorMsg(err, "could not instantiate the manifest service")
 	}
 
-	dwnService, err := dwn.NewDWNService(config.DWNConfig, storageProvider, keyStoreService)
+	dwnService, err := dwn.NewDWNService(config.DWNConfig, storageProvider, keyStoreService, manifestService)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not instantiate the dwn service")
 	}


### PR DESCRIPTION
should have caught this earlier. really we should think of the 'service' apis as all that are exposed to other services. storage should be internal to each service