### PR TITLE
hooking up did resolver and adding integ test for did:web

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -3,11 +3,11 @@ package integration
 import (
 	"bytes"
 	"embed"
-	cmpact "github.com/goccy/go-json"
-	"github.com/goccy/go-json"
 	"fmt"
 	manifestsdk "github.com/TBD54566975/ssi-sdk/credential/manifest"
 	"github.com/TBD54566975/ssi-sdk/crypto"
+	"github.com/goccy/go-json"
+	cmpact "github.com/goccy/go-json"
 	"github.com/mr-tron/base58"
 	"github.com/oliveagle/jsonpath"
 	"github.com/pkg/errors"
@@ -45,6 +45,16 @@ func CreateDIDWeb() (string, error) {
 	output, err := put(endpoint+version+"dids/web", getJSONFromFile("did-web-input.json"))
 	if err != nil {
 		return "", errors.Wrapf(err, "did endpoint with output: %s", output)
+	}
+
+	return output, nil
+}
+
+func ResolveDID(did string) (string, error) {
+	logrus.Println("\n\nResolve a did")
+	output, err := get(endpoint + version + "dids/resolver/" + did)
+	if err != nil {
+		return "", errors.Wrapf(err, "did resolver with output: %s", output)
 	}
 
 	return output, nil

--- a/integration/didweb_resolver_integration_test.go
+++ b/integration/didweb_resolver_integration_test.go
@@ -1,0 +1,29 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestResolveDIDWebIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	//A .wellKnown exists at https://identity.foundation/.well-known/did.json
+	didWebOutput, err := put(endpoint+version+"dids/web", `{ "keyType":"Ed25519", "didWebId":"did:web:identity.foundation"}`)
+	assert.NoError(t, err)
+
+	did, err := getJSONElement(didWebOutput, "$.did.id")
+
+	resolvedOutput, err := ResolveDID(did)
+	assert.NoError(t, err)
+
+	didError, err := getJSONElement(resolvedOutput, "$.didResolutionMetadata.Error")
+	assert.NoError(t, err)
+	assert.Equal(t, "<nil>", didError)
+
+	didDocumentID, err := getJSONElement(resolvedOutput, "$.didDocument.id")
+	assert.NoError(t, err)
+	assert.Equal(t, "did:web:identity.foundation", didDocumentID)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ const (
 	V1Prefix            = "/v1"
 	OperationPrefix     = "/operations"
 	DIDsPrefix          = "/dids"
+	ResolverPrefix      = "/resolver"
 	SchemasPrefix       = "/schemas"
 	CredentialsPrefix   = "/credentials"
 	StatusPrefix        = "/status"
@@ -124,6 +125,8 @@ func (s *SSIServer) DecentralizedIdentityAPI(service svcframework.Service) (err 
 	s.Handle(http.MethodPut, path.Join(handlerPath, "/:method"), didRouter.CreateDIDByMethod)
 	s.Handle(http.MethodGet, path.Join(handlerPath, "/:method"), didRouter.GetDIDsByMethod)
 	s.Handle(http.MethodGet, path.Join(handlerPath, "/:method/:id"), didRouter.GetDIDByMethod)
+
+	s.Handle(http.MethodGet, path.Join(path.Join(handlerPath, ResolverPrefix), "/:id"), didRouter.ResolveDID)
 	return
 }
 


### PR DESCRIPTION
# Overview
This change hooks up the did resolver to a route

# Description
did:key is self resolving
did:web requires a domain to resolve
An integration test is included that tests the did on a .wellKnown url at https://identity.foundation/.well-known/did.json

