### PR TITLE
Bump up patch version of golang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.4
 
     - name: Install Mage
       run: go install github.com/magefile/mage
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.4
 
     - name: Install mage
       run: go install github.com/magefile/mage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: 1.19.4
 
       - name: Install Mage
         run: go install github.com/magefile/mage

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: 1.19.4
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/steelthread.yml
+++ b/.github/workflows/steelthread.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.4
 
     - name: Install Mage
       run: go install github.com/magefile/mage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![godoc ssi-service](https://img.shields.io/badge/godoc-ssi--service-blue)](https://github.com/TBD54566975/ssi-service)
-[![go version 1.19.2](https://img.shields.io/badge/go_version-1.19.2-brightgreen)](https://go.dev/)
+[![go version 1.19.4](https://img.shields.io/badge/go_version-1.19.4-brightgreen)](https://go.dev/)
 [![license Apache 2](https://img.shields.io/badge/license-Apache%202-black)](https://github.com/TBD54566975/ssi-service/blob/main/LICENSE)
 [![issues](https://img.shields.io/github/issues/TBD54566975/ssi-service)](https://github.com/TBD54566975/ssi-service/issues)
 ![push](https://github.com/TBD54566975/ssi-service/workflows/ssi-service-ci/badge.svg?branch=main&event=push)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-alpine
+FROM golang:1.19.4-alpine
 
 # Create directory for our app inside the container
 WORKDIR /app


### PR DESCRIPTION
# Overview
This fixes the vulnerability in https://pkg.go.dev/vuln/GO-2022-1144
