### PR TITLE
In memory storage implementation

### DIFF
--- a/pkg/server/router/credential_test.go
+++ b/pkg/server/router/credential_test.go
@@ -40,16 +40,7 @@ func TestCredentialRouter(t *testing.T) {
 	})
 
 	t.Run("Credential Service Test", func(tt *testing.T) {
-
-		bolt, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, bolt)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		serviceConfig := config.CredentialServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "credential"}}
 		keyStoreService := testKeyStoreService(tt, bolt)
@@ -203,15 +194,7 @@ func TestCredentialRouter(t *testing.T) {
 	})
 
 	t.Run("Credential Status List Test", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, bolt)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		serviceConfig := config.CredentialServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "credential"}}
 		keyStoreService := testKeyStoreService(tt, bolt)
@@ -294,4 +277,8 @@ func TestCredentialRouter(t *testing.T) {
 		assert.NotEmpty(tt, credStatusMapTwo["statusListIndex"])
 
 	})
+}
+
+func setupTestDB(tt *testing.T) storage.ServiceStorage {
+	return &storage.MemoryDB{}
 }

--- a/pkg/server/router/did_test.go
+++ b/pkg/server/router/did_test.go
@@ -36,9 +36,7 @@ func TestDIDRouter(t *testing.T) {
 	})
 
 	t.Run("DID Service Test", func(tt *testing.T) {
-		db, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, db)
+		db := &storage.MemoryDB{}
 
 		keyStoreService := testKeyStoreService(tt, db)
 		methods := []string{didsdk.KeyMethod.String()}
@@ -105,11 +103,7 @@ func TestDIDRouter(t *testing.T) {
 	})
 
 	t.Run("DID Web Service Test", func(tt *testing.T) {
-		_ = os.Remove(storage.DBFile)
-
-		db, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, db)
+		db := &storage.MemoryDB{}
 
 		keyStoreService := testKeyStoreService(tt, db)
 		methods := []string{didsdk.KeyMethod.String(), didsdk.WebMethod.String()}

--- a/pkg/server/router/keystore_test.go
+++ b/pkg/server/router/keystore_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
@@ -15,11 +14,6 @@ import (
 )
 
 func TestKeyStoreRouter(t *testing.T) {
-
-	// remove the db file after the test
-	t.Cleanup(func() {
-		_ = os.Remove(storage.DBFile)
-	})
 
 	t.Run("Nil Service", func(tt *testing.T) {
 		keyStoreRouter, err := NewKeyStoreRouter(nil)
@@ -36,15 +30,13 @@ func TestKeyStoreRouter(t *testing.T) {
 	})
 
 	t.Run("Key Store Service Test", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, bolt)
+		db := &storage.MemoryDB{}
 
 		serviceConfig := config.KeyStoreServiceConfig{
 			BaseServiceConfig:  &config.BaseServiceConfig{Name: "keystore"},
 			ServiceKeyPassword: "test-password",
 		}
-		keyStoreService, err := keystore.NewKeyStoreService(serviceConfig, bolt)
+		keyStoreService, err := keystore.NewKeyStoreService(serviceConfig, db)
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, keyStoreService)
 

--- a/pkg/server/router/manifest_test.go
+++ b/pkg/server/router/manifest_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
@@ -23,10 +22,6 @@ import (
 )
 
 func TestManifestRouter(t *testing.T) {
-	// remove the db file after the test
-	t.Cleanup(func() {
-		_ = os.Remove(storage.DBFile)
-	})
 
 	t.Run("Nil Service", func(tt *testing.T) {
 		manifestRouter, err := NewManifestRouter(nil)
@@ -43,16 +38,13 @@ func TestManifestRouter(t *testing.T) {
 	})
 
 	t.Run("Manifest Service Test", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		assert.NoError(tt, err)
-		assert.NotEmpty(tt, bolt)
+		db := &storage.MemoryDB{}
 
-		keyStoreService := testKeyStoreService(tt, bolt)
-		didService := testDIDService(tt, bolt, keyStoreService)
-		schemaService := testSchemaService(tt, bolt, keyStoreService, didService)
-		credentialService := testCredentialService(tt, bolt, keyStoreService, didService, schemaService)
-		manifestService := testManifestService(tt, bolt, keyStoreService, didService, credentialService)
-		assert.NoError(tt, err)
+		keyStoreService := testKeyStoreService(tt, db)
+		didService := testDIDService(tt, db, keyStoreService)
+		schemaService := testSchemaService(tt, db, keyStoreService, didService)
+		credentialService := testCredentialService(tt, db, keyStoreService, didService, schemaService)
+		manifestService := testManifestService(tt, db, keyStoreService, didService, credentialService)
 		assert.NotEmpty(tt, manifestService)
 
 		// check type and status

--- a/pkg/server/router/schema_test.go
+++ b/pkg/server/router/schema_test.go
@@ -1,14 +1,11 @@
 package router
 
 import (
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
@@ -17,12 +14,6 @@ import (
 )
 
 func TestSchemaRouter(t *testing.T) {
-
-	// remove the db file after the test
-	t.Cleanup(func() {
-		_ = os.Remove(storage.DBFile)
-	})
-
 	t.Run("Nil Service", func(tt *testing.T) {
 		schemaRouter, err := NewSchemaRouter(nil)
 		assert.Error(tt, err)
@@ -38,14 +29,11 @@ func TestSchemaRouter(t *testing.T) {
 	})
 
 	t.Run("Schema Service Test", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-		require.NotEmpty(tt, bolt)
-
+		db := &storage.MemoryDB{}
 		serviceConfig := config.SchemaServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "schema"}}
-		keyStoreService := testKeyStoreService(tt, bolt)
-		didService := testDIDService(tt, bolt, keyStoreService)
-		schemaService, err := schema.NewSchemaService(serviceConfig, bolt, keyStoreService, didService.GetResolver())
+		keyStoreService := testKeyStoreService(tt, db)
+		didService := testDIDService(tt, db, keyStoreService)
+		schemaService, err := schema.NewSchemaService(serviceConfig, db, keyStoreService, didService.GetResolver())
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, schemaService)
 
@@ -123,20 +111,13 @@ func TestSchemaRouter(t *testing.T) {
 }
 
 func TestSchemaSigning(t *testing.T) {
-	// remove the db file after the test
-	t.Cleanup(func() {
-		_ = os.Remove(storage.DBFile)
-	})
-
 	t.Run("Unsigned Schema Test", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-		require.NotEmpty(tt, bolt)
+		db := &storage.MemoryDB{}
 
 		serviceConfig := config.SchemaServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "schema"}}
-		keyStoreService := testKeyStoreService(tt, bolt)
-		didService := testDIDService(tt, bolt, keyStoreService)
-		schemaService, err := schema.NewSchemaService(serviceConfig, bolt, keyStoreService, didService.GetResolver())
+		keyStoreService := testKeyStoreService(tt, db)
+		didService := testDIDService(tt, db, keyStoreService)
+		schemaService, err := schema.NewSchemaService(serviceConfig, db, keyStoreService, didService.GetResolver())
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, schemaService)
 

--- a/pkg/server/router/testutils_test.go
+++ b/pkg/server/router/testutils_test.go
@@ -47,7 +47,7 @@ func testSchemaService(t *testing.T, db storage.ServiceStorage, keyStore *keysto
 	return schemaService
 }
 
-func testCredentialService(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, did *did.Service, schema *schema.Service) *credential.Service {
+func testCredentialService(t *testing.T, db storage.ServiceStorage, keyStore *keystore.Service, did *did.Service, schema *schema.Service) *credential.Service {
 	serviceConfig := config.CredentialServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "credential"}}
 	// create a credential service
 	credentialService, err := credential.NewCredentialService(serviceConfig, db, keyStore, did.GetResolver(), schema)
@@ -56,7 +56,7 @@ func testCredentialService(t *testing.T, db *storage.BoltDB, keyStore *keystore.
 	return credentialService
 }
 
-func testManifestService(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, did *did.Service, credential *credential.Service) *manifest.Service {
+func testManifestService(t *testing.T, db storage.ServiceStorage, keyStore *keystore.Service, did *did.Service, credential *credential.Service) *manifest.Service {
 	serviceConfig := config.ManifestServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "manifest"}}
 	// create a manifest service
 	manifestService, err := manifest.NewManifestService(serviceConfig, db, keyStore, did.GetResolver(), credential)

--- a/pkg/server/server_credential_test.go
+++ b/pkg/server/server_credential_test.go
@@ -4,36 +4,24 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
-
 	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
 	"github.com/tbd54566975/ssi-service/pkg/service/schema"
-	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
 func TestCredentialAPI(t *testing.T) {
 	t.Run("Test Create Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -108,14 +96,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Create Credential with Schema", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -206,14 +187,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Credential By ID", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -224,7 +198,7 @@ func TestCredentialAPI(t *testing.T) {
 
 		// get a cred that doesn't exit
 		req := httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/credentials/bad", nil)
-		err = credRouter.GetCredential(newRequestContext(), w, req)
+		err := credRouter.GetCredential(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cannot get credential without ID parameter")
 
@@ -282,14 +256,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Credential By Schema", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -361,14 +328,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Credential By Issuer", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -420,14 +380,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Credential By Subject", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -481,14 +434,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Delete Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -552,14 +498,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Verifying a Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -625,14 +564,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Create Revocable Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -801,14 +733,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Revoked Status Of Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -879,14 +804,7 @@ func TestCredentialAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Status List Credential", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)

--- a/pkg/server/server_did_test.go
+++ b/pkg/server/server_did_test.go
@@ -4,29 +4,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
-	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
 func TestDIDAPI(t *testing.T) {
 	t.Run("Test Get DID Methods", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		_, keyStoreService := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStoreService)
@@ -35,7 +24,7 @@ func TestDIDAPI(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/dids", nil)
 		w := httptest.NewRecorder()
 
-		err = didService.GetDIDMethods(newRequestContext(), w, req)
+		err := didService.GetDIDMethods(newRequestContext(), w, req)
 		assert.NoError(tt, err)
 		assert.Equal(tt, http.StatusOK, w.Result().StatusCode)
 
@@ -48,14 +37,7 @@ func TestDIDAPI(t *testing.T) {
 	})
 
 	t.Run("Test Create DID By Method: Key", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		_, keyStoreService := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStoreService)
@@ -67,7 +49,7 @@ func TestDIDAPI(t *testing.T) {
 			"method": "key",
 		}
 
-		err = didService.CreateDIDByMethod(newRequestContextWithParams(params), w, req)
+		err := didService.CreateDIDByMethod(newRequestContextWithParams(params), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "invalid create DID request")
 
@@ -102,14 +84,7 @@ func TestDIDAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get DID By Method", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		_, keyStore := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStore)
@@ -123,7 +98,7 @@ func TestDIDAPI(t *testing.T) {
 			"method": "bad",
 			"id":     "worse",
 		}
-		err = didService.GetDIDByMethod(newRequestContextWithParams(badParams), w, req)
+		err := didService.GetDIDByMethod(newRequestContextWithParams(badParams), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "could not get DID for method<bad>")
 
@@ -177,14 +152,7 @@ func TestDIDAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get DIDs By Method", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		_, keyStore := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStore)
@@ -197,7 +165,7 @@ func TestDIDAPI(t *testing.T) {
 		badParams := map[string]string{
 			"method": "bad",
 		}
-		err = didService.GetDIDsByMethod(newRequestContextWithParams(badParams), w, req)
+		err := didService.GetDIDsByMethod(newRequestContextWithParams(badParams), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "could not get DIDs for method: bad")
 
@@ -266,14 +234,7 @@ func TestDIDAPI(t *testing.T) {
 	})
 
 	t.Run("Test Resolve DIDs", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		_, keyStore := testKeyStore(tt, bolt)
 		didService := testDIDRouter(tt, bolt, keyStore)
@@ -285,7 +246,7 @@ func TestDIDAPI(t *testing.T) {
 		badParams := map[string]string{
 			"id": "bad",
 		}
-		err = didService.ResolveDID(newRequestContextWithParams(badParams), w, req)
+		err := didService.ResolveDID(newRequestContextWithParams(badParams), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "not a valid did: bad")
 

--- a/pkg/server/server_keystore_test.go
+++ b/pkg/server/server_keystore_test.go
@@ -4,29 +4,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/goccy/go-json"
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
-	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
 func TestKeyStoreAPI(t *testing.T) {
 	t.Run("Test Store Key", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreRouter, _ := testKeyStore(tt, bolt)
 		w := httptest.NewRecorder()
@@ -40,7 +29,7 @@ func TestKeyStoreAPI(t *testing.T) {
 		}
 		badRequestValue := newRequestValue(tt, badKeyStoreRequest)
 		req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/keys", badRequestValue)
-		err = keyStoreRouter.StoreKey(newRequestContext(), w, req)
+		err := keyStoreRouter.StoreKey(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "unsupported key type: bad")
 
@@ -69,14 +58,7 @@ func TestKeyStoreAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Key Details", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService, _ := testKeyStore(tt, bolt)
 		w := httptest.NewRecorder()

--- a/pkg/server/server_manifest_test.go
+++ b/pkg/server/server_manifest_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
@@ -12,8 +11,6 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	credmodel "github.com/tbd54566975/ssi-service/internal/credential"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
@@ -21,19 +18,11 @@ import (
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
 	manifestsvc "github.com/tbd54566975/ssi-service/pkg/service/manifest"
 	"github.com/tbd54566975/ssi-service/pkg/service/schema"
-	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
 func TestManifestAPI(t *testing.T) {
 	t.Run("Test Create Manifest", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -47,7 +36,7 @@ func TestManifestAPI(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/manifests", badRequestValue)
 		w := httptest.NewRecorder()
 
-		err = manifestRouter.CreateManifest(newRequestContext(), w, req)
+		err := manifestRouter.CreateManifest(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "invalid create manifest request")
 
@@ -99,14 +88,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Manifest By ID", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -118,7 +100,7 @@ func TestManifestAPI(t *testing.T) {
 
 		// get a manifest that doesn't exit
 		req := httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/manifests/bad", nil)
-		err = manifestRouter.GetManifest(newRequestContext(), w, req)
+		err := manifestRouter.GetManifest(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cannot get manifest without ID parameter")
 
@@ -181,14 +163,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Manifests", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -254,14 +229,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Delete Manifest", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -334,14 +302,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Submit Application", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -358,7 +319,7 @@ func TestManifestAPI(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/manifests/applications", badRequestValue)
 		w := httptest.NewRecorder()
 
-		err = manifestRouter.SubmitApplication(newRequestContext(), w, req)
+		err := manifestRouter.SubmitApplication(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "invalid submit application request")
 
@@ -457,14 +418,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Denied Application", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -481,7 +435,7 @@ func TestManifestAPI(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/manifests/applications", badRequestValue)
 		w := httptest.NewRecorder()
 
-		err = manifestRouter.SubmitApplication(newRequestContext(), w, req)
+		err := manifestRouter.SubmitApplication(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "invalid submit application request")
 
@@ -608,14 +562,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Get Application By ID and Get Applications", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)
@@ -626,7 +573,7 @@ func TestManifestAPI(t *testing.T) {
 
 		// get a application that doesn't exit
 		req := httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/manifests/applications/bad", nil)
-		err = manifestRouter.GetApplication(newRequestContext(), w, req)
+		err := manifestRouter.GetApplication(newRequestContext(), w, req)
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "cannot get application without ID parameter")
 
@@ -763,14 +710,7 @@ func TestManifestAPI(t *testing.T) {
 	})
 
 	t.Run("Test Delete Application", func(tt *testing.T) {
-		bolt, err := storage.NewBoltDB()
-		require.NoError(tt, err)
-
-		// remove the db file after the test
-		tt.Cleanup(func() {
-			_ = bolt.Close()
-			_ = os.Remove(storage.DBFile)
-		})
+		bolt := setupTestDB(tt)
 
 		keyStoreService := testKeyStoreService(tt, bolt)
 		didService := testDIDService(tt, bolt, keyStoreService)

--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
@@ -12,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
@@ -223,16 +221,7 @@ func TestOperationsAPI(t *testing.T) {
 }
 
 func setupTestDB(t *testing.T) storage.ServiceStorage {
-	file, err := os.CreateTemp("", "bolt")
-	require.NoError(t, err)
-	name := file.Name()
-	s, err := storage.NewBoltDBWithFile(name)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = s.Close()
-		_ = os.Remove(name)
-	})
-	return s
+	return &storage.MemoryDB{}
 }
 
 func reviewSubmission(t *testing.T, pRouter *router.PresentationRouter, submissionID string) router.ReviewSubmissionResponse {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -184,7 +184,7 @@ func getValidApplicationRequest(manifestID, presDefID, submissionDescriptorID st
 	}
 }
 
-func testKeyStore(t *testing.T, bolt *storage.BoltDB) (*router.KeyStoreRouter, *keystore.Service) {
+func testKeyStore(t *testing.T, bolt storage.ServiceStorage) (*router.KeyStoreRouter, *keystore.Service) {
 	keyStoreService := testKeyStoreService(t, bolt)
 
 	// create router for service
@@ -222,7 +222,7 @@ func testDIDService(t *testing.T, bolt storage.ServiceStorage, keyStore *keystor
 	return didService
 }
 
-func testDIDRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service) *router.DIDRouter {
+func testDIDRouter(t *testing.T, bolt storage.ServiceStorage, keyStore *keystore.Service) *router.DIDRouter {
 	didService := testDIDService(t, bolt, keyStore)
 
 	// create router for service
@@ -239,7 +239,7 @@ func testSchemaService(t *testing.T, bolt storage.ServiceStorage, keyStore *keys
 	return schemaService
 }
 
-func testSchemaRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service, did *did.Service) *router.SchemaRouter {
+func testSchemaRouter(t *testing.T, bolt storage.ServiceStorage, keyStore *keystore.Service, did *did.Service) *router.SchemaRouter {
 	schemaService := testSchemaService(t, bolt, keyStore, did)
 
 	// create router for service
@@ -259,7 +259,7 @@ func testCredentialService(t *testing.T, db storage.ServiceStorage, keyStore *ke
 	return credentialService
 }
 
-func testCredentialRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore.Service, did *did.Service, schema *schema.Service) *router.CredentialRouter {
+func testCredentialRouter(t *testing.T, bolt storage.ServiceStorage, keyStore *keystore.Service, did *did.Service, schema *schema.Service) *router.CredentialRouter {
 	credentialService := testCredentialService(t, bolt, keyStore, did, schema)
 
 	// create router for service
@@ -270,7 +270,7 @@ func testCredentialRouter(t *testing.T, bolt *storage.BoltDB, keyStore *keystore
 	return credentialRouter
 }
 
-func testManifest(t *testing.T, db *storage.BoltDB, keyStore *keystore.Service, did *did.Service, credential *credential.Service) (*router.ManifestRouter, *manifest.Service) {
+func testManifest(t *testing.T, db storage.ServiceStorage, keyStore *keystore.Service, did *did.Service, credential *credential.Service) (*router.ManifestRouter, *manifest.Service) {
 	serviceConfig := config.ManifestServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "manifest"}}
 	// create a manifest service
 	manifestService, err := manifest.NewManifestService(serviceConfig, db, keyStore, did.GetResolver(), credential)

--- a/pkg/service/credential/storage/bolt.go
+++ b/pkg/service/credential/storage/bolt.go
@@ -30,14 +30,14 @@ const (
 )
 
 type BoltCredentialStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
 type StatusListIndex struct {
 	Index int `json:"index"`
 }
 
-func NewBoltCredentialStorage(db *storage.BoltDB) (*BoltCredentialStorage, error) {
+func NewBoltCredentialStorage(db storage.ServiceStorage) (*BoltCredentialStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/credential/storage/storage.go
+++ b/pkg/service/credential/storage/storage.go
@@ -60,18 +60,9 @@ type Storage interface {
 }
 
 func NewCredentialStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltCredentialStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate credential bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltCredentialStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate credential bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/service/did/storage/bolt.go
+++ b/pkg/service/did/storage/bolt.go
@@ -25,10 +25,10 @@ var (
 )
 
 type BoltDIDStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
-func NewBoltDIDStorage(db *storage.BoltDB) (*BoltDIDStorage, error) {
+func NewBoltDIDStorage(db storage.ServiceStorage) (*BoltDIDStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/did/storage/storage.go
+++ b/pkg/service/did/storage/storage.go
@@ -21,18 +21,9 @@ type Storage interface {
 
 // NewDIDStorage finds the DID storage impl for a given ServiceStorage value
 func NewDIDStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltDIDStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate credential bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltDIDStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate credential bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/service/keystore/service_test.go
+++ b/pkg/service/keystore/service_test.go
@@ -1,7 +1,6 @@
 package keystore
 
 import (
-	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
@@ -91,15 +90,7 @@ func TestEncryptDecryptAllKeyTypes(t *testing.T) {
 }
 
 func TestStoreAndGetKey(t *testing.T) {
-	bolt, err := storage.NewBoltDB()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, bolt)
-
-	// remove the db file after the test
-	t.Cleanup(func() {
-		_ = bolt.Close()
-		_ = os.Remove(storage.DBFile)
-	})
+	db := &storage.MemoryDB{}
 
 	keyStore, err := NewKeyStoreService(
 		config.KeyStoreServiceConfig{
@@ -108,7 +99,7 @@ func TestStoreAndGetKey(t *testing.T) {
 			},
 			ServiceKeyPassword: "test-password",
 		},
-		bolt)
+		db)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, keyStore)
 

--- a/pkg/service/keystore/storage/bolt.go
+++ b/pkg/service/keystore/storage/bolt.go
@@ -16,11 +16,11 @@ const (
 )
 
 type BoltKeyStoreStorage struct {
-	db         *storage.BoltDB
+	db         storage.ServiceStorage
 	serviceKey []byte
 }
 
-func NewBoltKeyStoreStorage(db *storage.BoltDB, key ServiceKey) (*BoltKeyStoreStorage, error) {
+func NewBoltKeyStoreStorage(db storage.ServiceStorage, key ServiceKey) (*BoltKeyStoreStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/keystore/storage/storage.go
+++ b/pkg/service/keystore/storage/storage.go
@@ -36,21 +36,12 @@ type Storage interface {
 }
 
 func NewKeyStoreStorage(s storage.ServiceStorage, serviceKey, serviceKeySalt string) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltKeyStoreStorage(gotBolt, ServiceKey{
-			Base58Key:  serviceKey,
-			Base58Salt: serviceKeySalt,
-		})
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate key store bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltKeyStoreStorage(s, ServiceKey{
+		Base58Key:  serviceKey,
+		Base58Salt: serviceKeySalt,
+	})
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate key store bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/service/manifest/storage/bolt.go
+++ b/pkg/service/manifest/storage/bolt.go
@@ -18,10 +18,10 @@ const (
 )
 
 type BoltManifestStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
-func NewBoltManifestStorage(db *storage.BoltDB) (*BoltManifestStorage, error) {
+func NewBoltManifestStorage(db storage.ServiceStorage) (*BoltManifestStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/manifest/storage/storage.go
+++ b/pkg/service/manifest/storage/storage.go
@@ -63,18 +63,9 @@ type CredentialResponseStorage interface {
 
 // NewManifestStorage finds the manifest storage impl for a given ServiceStorage value
 func NewManifestStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltManifestStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate manifest bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltManifestStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate manifest bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/service/operation/storage/bolt.go
+++ b/pkg/service/operation/storage/bolt.go
@@ -37,7 +37,7 @@ func namespaceFromParent(parent string) string {
 }
 
 type BoltOperationStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
 func (b BoltOperationStorage) StoreOperation(op StoredOperation) error {
@@ -103,7 +103,7 @@ func (b BoltOperationStorage) DeleteOperation(id string) error {
 	return nil
 }
 
-func NewBoltOperationStorage(db *storage.BoltDB) (*BoltOperationStorage, error) {
+func NewBoltOperationStorage(db storage.ServiceStorage) (*BoltOperationStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/operation/storage/storage.go
+++ b/pkg/service/operation/storage/storage.go
@@ -38,18 +38,9 @@ type Storage interface {
 }
 
 func NewOperationStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltOperationStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltOperationStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/service/presentation/storage/bolt.go
+++ b/pkg/service/presentation/storage/bolt.go
@@ -18,7 +18,7 @@ const (
 )
 
 type BoltPresentationStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
 type opUpdater struct {
@@ -107,7 +107,7 @@ func (b BoltPresentationStorage) ListSubmissions(filter filtering.Filter) ([]Sto
 	return storedSubmissions, nil
 }
 
-func NewBoltPresentationStorage(db *storage.BoltDB) (*BoltPresentationStorage, error) {
+func NewBoltPresentationStorage(db storage.ServiceStorage) (*BoltPresentationStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -28,20 +28,11 @@ type DefinitionStorage interface {
 
 // NewPresentationStorage finds the presentation storage impl for a given ServiceStorage value
 func NewPresentationStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltPresentationStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltPresentationStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
 	}
+	return boltStorage, err
 }
 
 type Status uint8

--- a/pkg/service/schema/storage/bolt.go
+++ b/pkg/service/schema/storage/bolt.go
@@ -15,10 +15,10 @@ const (
 )
 
 type BoltSchemaStorage struct {
-	db *storage.BoltDB
+	db storage.ServiceStorage
 }
 
-func NewBoltSchemaStorage(db *storage.BoltDB) (*BoltSchemaStorage, error) {
+func NewBoltSchemaStorage(db storage.ServiceStorage) (*BoltSchemaStorage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}

--- a/pkg/service/schema/storage/storage.go
+++ b/pkg/service/schema/storage/storage.go
@@ -24,18 +24,9 @@ type Storage interface {
 
 // NewSchemaStorage finds the schema storage impl for a given ServiceStorage value
 func NewSchemaStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltSchemaStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	boltStorage, err := NewBoltSchemaStorage(s)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
 	}
+	return boltStorage, err
 }

--- a/pkg/storage/bolt.go
+++ b/pkg/storage/bolt.go
@@ -204,9 +204,9 @@ func (b *BoltDB) UpdateValueAndOperation(namespace, key string, updater Updater,
 	return first, op, err
 }
 
-func (b *BoltDB) Update(namespace string, key string, values map[string]any) ([]byte, error) {
+func (b *BoltDB) Update(namespace string, key string, updater Updater) ([]byte, error) {
 	var updatedData []byte
-	err := b.db.Update(updateTxFn(namespace, key, NewUpdater(values), &updatedData))
+	err := b.db.Update(updateTxFn(namespace, key, updater, &updatedData))
 	return updatedData, err
 }
 

--- a/pkg/storage/bolt_test.go
+++ b/pkg/storage/bolt_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/goccy/go-json"
@@ -130,16 +129,8 @@ func TestBoltDBPrefixAndKeys(t *testing.T) {
 	assert.Contains(t, allKeys, "tezos-mainnet")
 }
 
-func setupBoltDB(t *testing.T) *BoltDB {
-	db, err := NewBoltDBWithFile("test.db")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, db)
-
-	t.Cleanup(func() {
-		_ = db.Close()
-		_ = os.Remove("test.db")
-	})
-	return db
+func setupBoltDB(t *testing.T) ServiceStorage {
+	return &MemoryDB{}
 }
 
 type testStruct struct {
@@ -203,7 +194,7 @@ func TestBoltDB_Update(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err = db.Update(namespace, tt.args.key, tt.args.values)
+			data, err = db.Update(namespace, tt.args.key, NewUpdater(tt.args.values))
 			if !tt.expectedError(t, err) {
 				return
 			}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -1,9 +1,10 @@
 package storage
 
 import (
-	"github.com/pkg/errors"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // MemoryDB is an in memory implementation of ServiceStorage that is safe for concurrent use.

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -1,0 +1,162 @@
+package storage
+
+import (
+	"github.com/pkg/errors"
+	"strings"
+	"sync"
+)
+
+// MemoryDB is an in memory implementation of ServiceStorage that is safe for concurrent use.
+type MemoryDB struct {
+	maps sync.Map
+}
+
+func (f *MemoryDB) Update(namespace string, key string, updater Updater) ([]byte, error) {
+	v, err := f.Read(namespace, key)
+	if err != nil {
+		return nil, err
+	}
+	if err = updater.Validate(v); err != nil {
+		return nil, err
+	}
+	updatedV, err := updater.Update(v)
+	if err != nil {
+		return nil, err
+	}
+	if err = f.Write(namespace, key, updatedV); err != nil {
+		return nil, err
+	}
+	return updatedV, nil
+}
+
+func (f *MemoryDB) ReadPrefix(namespace, prefix string) (map[string][]byte, error) {
+	if namespace == "" {
+		return nil, nil
+	}
+	m, _ := f.maps.LoadOrStore(namespace, &sync.Map{})
+	r := make(map[string][]byte)
+	m.(*sync.Map).Range(func(key, value any) bool {
+		if strings.HasPrefix(key.(string), prefix) {
+			r[key.(string)] = value.([]byte)
+		}
+		return true
+	})
+	return r, nil
+}
+
+func (f *MemoryDB) ReadAllKeys(namespace string) ([]string, error) {
+	if namespace == "" {
+		return nil, nil
+	}
+	m, _ := f.maps.LoadOrStore(namespace, &sync.Map{})
+	r := make([]string, 0, 10)
+	m.(*sync.Map).Range(func(key, value any) bool {
+		r = append(r, key.(string))
+		return true
+	})
+	return r, nil
+}
+
+func (f *MemoryDB) UpdateValueAndOperation(namespace, key string, updater Updater, opNamespace, opKey string, rUpdater ResponseSettingUpdater) ([]byte, []byte, error) {
+	updatedV, err := f.Update(namespace, key, updater)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	op, err := f.Read(opNamespace, opKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = rUpdater.Validate(op); err != nil {
+		return nil, nil, err
+	}
+	rUpdater.SetUpdatedResponse(updatedV)
+	opUpdated, err := rUpdater.Update(op)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = f.Write(opNamespace, opKey, opUpdated); err != nil {
+		return nil, nil, err
+	}
+	return updatedV, opUpdated, nil
+}
+
+func (f *MemoryDB) Type() Storage {
+	return "in memory test storage"
+}
+
+func (f *MemoryDB) Close() error {
+	return nil
+}
+
+func (f *MemoryDB) Write(namespace, key string, value []byte) error {
+	if namespace == "" {
+		return errors.New("namespace required")
+	}
+	if key == "" {
+		return errors.New("key required")
+	}
+
+	b, _ := f.maps.LoadOrStore(namespace, &sync.Map{})
+	b.(*sync.Map).Store(key, value)
+	return nil
+}
+
+func (f *MemoryDB) Read(namespace, key string) ([]byte, error) {
+	if namespace == "" {
+		// This is what the bolt implementation does.
+		return nil, nil
+	}
+	if key == "" {
+		return nil, errors.New("key required")
+	}
+	m, ok := f.maps.Load(namespace)
+	if !ok {
+		return nil, nil
+	}
+
+	v, _ := m.(*sync.Map).Load(key)
+	if v == nil {
+		return nil, nil
+	}
+	return v.([]byte), nil
+}
+
+func (f *MemoryDB) ReadAll(namespace string) (map[string][]byte, error) {
+	if namespace == "" {
+		return nil, nil
+	}
+	m, _ := f.maps.LoadOrStore(namespace, &sync.Map{})
+	r := make(map[string][]byte)
+	m.(*sync.Map).Range(func(key, value any) bool {
+		r[key.(string)] = value.([]byte)
+		return true
+	})
+	return r, nil
+}
+
+func (f *MemoryDB) Delete(namespace, key string) error {
+	if namespace == "" {
+		return errors.New("namespace required")
+	}
+	if key == "" {
+		return errors.New("key required")
+	}
+
+	b, ok := f.maps.Load(namespace)
+	if !ok {
+		return errors.Errorf("namespace<%s> does not exist", namespace)
+	}
+	b.(*sync.Map).Delete(key)
+	return nil
+}
+
+func (f *MemoryDB) DeleteNamespace(namespace string) error {
+	if namespace == "" {
+		return errors.New("namespace required")
+	}
+	if _, loaded := f.maps.LoadAndDelete(namespace); !loaded {
+		return errors.Errorf("could not delete namespace<%s>", namespace)
+	}
+	return nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -19,6 +19,10 @@ type ServiceStorage interface {
 	ReadAll(namespace string) (map[string][]byte, error)
 	Delete(namespace, key string) error
 	DeleteNamespace(namespace string) error
+	UpdateValueAndOperation(namespace, key string, updater Updater, opNamespace, opKey string, opUpdater ResponseSettingUpdater) ([]byte, []byte, error)
+	ReadPrefix(namespace, prefix string) (map[string][]byte, error)
+	ReadAllKeys(namespace string) ([]string, error)
+	Update(namespace string, key string, updater Updater) ([]byte, error)
 }
 
 // NewStorage creates a new storage provider based on the input


### PR DESCRIPTION
Implemented an in-memory storage conforming to the `ServiceStorage` interface. As part of this, some additional methods were added to the `ServiceStorage`.

Additionally, I changed all tests so they us the in-memory implementation. This makes it simpler to reinstantiate tests. 

