### PR TITLE
[OSE-176] Operations can be cancelled

### DIFF
--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -479,7 +479,7 @@ definitions:
           context values.
         type: string
       data:
-        additionalProperties: true
+        additionalProperties: {}
         type: object
       expiry:
         type: string
@@ -770,7 +770,7 @@ definitions:
         description: The reason why the submission was approved or denied.
         type: string
       status:
-        description: One of {`pending`, `approved`, `denied`}.
+        description: One of {`pending`, `approved`, `denied`, `cancelled`}.
         type: string
     required:
     - definition_id
@@ -790,7 +790,7 @@ definitions:
     properties:
       submissions:
         items:
-          $ref: '#/definitions/presentation.Submission'
+          $ref: '#/definitions/model.Submission'
         type: array
     type: object
   github.com_tbd54566975_ssi-service_pkg_server_router.Operation:
@@ -846,7 +846,7 @@ definitions:
         description: The reason why the submission was approved or denied.
         type: string
       status:
-        description: One of {`pending`, `approved`, `denied`}.
+        description: One of {`pending`, `approved`, `denied`, `cancelled`}.
         type: string
     required:
     - definition_id
@@ -1044,6 +1044,28 @@ definitions:
     - id
     - schema
     type: object
+  model.Submission:
+    properties:
+      definition_id:
+        type: string
+      descriptor_map:
+        items:
+          $ref: '#/definitions/exchange.SubmissionDescriptor'
+        type: array
+      id:
+        type: string
+      reason:
+        description: The reason why the submission was approved or denied.
+        type: string
+      status:
+        description: One of {`pending`, `approved`, `denied`, `cancelled`}.
+        type: string
+    required:
+    - definition_id
+    - descriptor_map
+    - id
+    - status
+    type: object
   pkg_server_router.CreateCredentialRequest:
     properties:
       '@context':
@@ -1051,7 +1073,7 @@ definitions:
           context values.
         type: string
       data:
-        additionalProperties: true
+        additionalProperties: {}
         type: object
       expiry:
         type: string
@@ -1342,7 +1364,7 @@ definitions:
         description: The reason why the submission was approved or denied.
         type: string
       status:
-        description: One of {`pending`, `approved`, `denied`}.
+        description: One of {`pending`, `approved`, `denied`, `cancelled`}.
         type: string
     required:
     - definition_id
@@ -1362,7 +1384,7 @@ definitions:
     properties:
       submissions:
         items:
-          $ref: '#/definitions/presentation.Submission'
+          $ref: '#/definitions/model.Submission'
         type: array
     type: object
   pkg_server_router.Operation:
@@ -1418,7 +1440,7 @@ definitions:
         description: The reason why the submission was approved or denied.
         type: string
       status:
-        description: One of {`pending`, `approved`, `denied`}.
+        description: One of {`pending`, `approved`, `denied`, `cancelled`}.
         type: string
     required:
     - definition_id
@@ -1500,28 +1522,6 @@ definitions:
         type: string
       verified:
         type: boolean
-    type: object
-  presentation.Submission:
-    properties:
-      definition_id:
-        type: string
-      descriptor_map:
-        items:
-          $ref: '#/definitions/exchange.SubmissionDescriptor'
-        type: array
-      id:
-        type: string
-      reason:
-        description: The reason why the submission was approved or denied.
-        type: string
-      status:
-        description: One of {`pending`, `approved`, `denied`}.
-        type: string
-    required:
-    - definition_id
-    - descriptor_map
-    - id
-    - status
     type: object
   rendering.ColorResource:
     properties:
@@ -2411,7 +2411,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetOperationsResponse'
+            $ref: '#/definitions/pkg_server_router.Operation'
         "400":
           description: Bad request
           schema:
@@ -2440,7 +2440,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.Operation'
+            $ref: '#/definitions/pkg_server_router.Operation'
         "400":
           description: Bad request
           schema:

--- a/pkg/server/router/operation.go
+++ b/pkg/server/router/operation.go
@@ -162,10 +162,6 @@ func routerModel(op operation.Operation) Operation {
 	}
 }
 
-type GetCancelOperationResponse struct {
-	Operation operation.Operation
-}
-
 // CancelOperation godoc
 // @Summary      Cancel an ongoing operation
 // @Description  Cancels an ongoing operation, if possible.

--- a/pkg/server/router/operation.go
+++ b/pkg/server/router/operation.go
@@ -162,6 +162,10 @@ func routerModel(op operation.Operation) Operation {
 	}
 }
 
+type GetCancelOperationResponse struct {
+	Operation operation.Operation
+}
+
 // CancelOperation godoc
 // @Summary      Cancel an ongoing operation
 // @Description  Cancels an ongoing operation, if possible.
@@ -169,10 +173,22 @@ func routerModel(op operation.Operation) Operation {
 // @Accept       json
 // @Produce      json
 // @Param        id   path      string  true  "ID"
-// @Success      200  {object}  GetOperationsResponse  "OK"
+// @Success      200  {object}  Operation  "OK"
 // @Failure      400  {string}  string  "Bad request"
 // @Failure      500  {string}  string  "Internal server error"
 // @Router       /v1/operations [get]
 func (o OperationRouter) CancelOperation(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	return nil
+	id := framework.GetParam(ctx, IDParam)
+	if id == nil {
+		return framework.NewRequestError(
+			util.LoggingNewError("get operation request requires id"), http.StatusBadRequest)
+	}
+
+	op, err := o.service.CancelOperation(operation.CancelOperationRequest{ID: *id})
+
+	if err != nil {
+		return framework.NewRequestError(
+			util.LoggingErrorMsg(err, "failed cancelling operation"), http.StatusInternalServerError)
+	}
+	return framework.Respond(ctx, w, routerModel(op), http.StatusOK)
 }

--- a/pkg/server/router/operation.go
+++ b/pkg/server/router/operation.go
@@ -53,7 +53,7 @@ func (o OperationRouter) GetOperation(ctx context.Context, w http.ResponseWriter
 		return framework.NewRequestError(
 			util.LoggingErrorMsg(err, "failed getting operation"), http.StatusInternalServerError)
 	}
-	return framework.Respond(ctx, w, routerModel(op), http.StatusOK)
+	return framework.Respond(ctx, w, routerModel(*op), http.StatusOK)
 }
 
 type GetOperationsRequest struct {
@@ -186,5 +186,5 @@ func (o OperationRouter) CancelOperation(ctx context.Context, w http.ResponseWri
 		return framework.NewRequestError(
 			util.LoggingErrorMsg(err, "failed cancelling operation"), http.StatusInternalServerError)
 	}
-	return framework.Respond(ctx, w, routerModel(op), http.StatusOK)
+	return framework.Respond(ctx, w, routerModel(*op), http.StatusOK)
 }

--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
-	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
@@ -28,7 +28,7 @@ func TestOperationsAPI(t *testing.T) {
 		holderSigner, holderDID := getSigner(t)
 		definition := createPresentationDefinition(t, pRouter)
 		submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-		submission := reviewSubmission(t, pRouter, opstorage.SubmissionID(submissionOp.ID))
+		sub := reviewSubmission(t, pRouter, submission.ResourceID(submissionOp.ID))
 
 		createdID := submissionOp.ID
 		req := httptest.NewRequest(
@@ -44,7 +44,7 @@ func TestOperationsAPI(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 		assert.True(t, resp.Done)
 		assert.Empty(t, resp.Result.Error)
-		data, err := json.Marshal(submission)
+		data, err := json.Marshal(sub)
 		assert.NoError(t, err)
 		var responseAsMap map[string]any
 		assert.NoError(t, json.Unmarshal(data, &responseAsMap))
@@ -257,7 +257,7 @@ func TestOperationsAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			_ = reviewSubmission(t, pRouter, opstorage.SubmissionID(submissionOp.ID))
+			_ = reviewSubmission(t, pRouter, submission.ResourceID(submissionOp.ID))
 
 			createdID := submissionOp.ID
 			req := httptest.NewRequest(

--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -28,7 +28,7 @@ func TestOperationsAPI(t *testing.T) {
 		holderSigner, holderDID := getSigner(t)
 		definition := createPresentationDefinition(t, pRouter)
 		submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-		sub := reviewSubmission(t, pRouter, submission.ResourceID(submissionOp.ID))
+		sub := reviewSubmission(t, pRouter, submission.ID(submissionOp.ID))
 
 		createdID := submissionOp.ID
 		req := httptest.NewRequest(
@@ -257,7 +257,7 @@ func TestOperationsAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			_ = reviewSubmission(t, pRouter, submission.ResourceID(submissionOp.ID))
+			_ = reviewSubmission(t, pRouter, submission.ID(submissionOp.ID))
 
 			createdID := submissionOp.ID
 			req := httptest.NewRequest(

--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	storage2 "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
+	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 )
 
@@ -28,7 +28,7 @@ func TestOperationsAPI(t *testing.T) {
 		holderSigner, holderDID := getSigner(t)
 		definition := createPresentationDefinition(t, pRouter)
 		submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-		submission := reviewSubmission(t, pRouter, storage2.SubmissionID(submissionOp.ID))
+		submission := reviewSubmission(t, pRouter, opstorage.SubmissionID(submissionOp.ID))
 
 		createdID := submissionOp.ID
 		req := httptest.NewRequest(
@@ -257,7 +257,7 @@ func TestOperationsAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			_ = reviewSubmission(t, pRouter, storage2.SubmissionID(submissionOp.ID))
+			_ = reviewSubmission(t, pRouter, opstorage.SubmissionID(submissionOp.ID))
 
 			createdID := submissionOp.ID
 			req := httptest.NewRequest(

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	storage2 "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
+	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation/model"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
@@ -163,14 +163,14 @@ func TestPresentationAPI(t *testing.T) {
 					"id":             "did:web:andresuribe.com",
 				})), holderDID, holderSigner)
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", storage2.SubmissionID(op.ID)), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", opstorage.SubmissionID(op.ID)), nil)
 			w := httptest.NewRecorder()
 
-			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": storage2.SubmissionID(op.ID)}), w, req))
+			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": opstorage.SubmissionID(op.ID)}), w, req))
 
 			var resp router.GetSubmissionResponse
 			assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-			assert.Equal(t, storage2.SubmissionID(op.ID), resp.Submission.ID)
+			assert.Equal(t, opstorage.SubmissionID(op.ID), resp.Submission.ID)
 			assert.Equal(t, definition.PresentationDefinition.ID, resp.Submission.DefinitionID)
 			assert.Equal(t, "pending", resp.Submission.Status)
 		})
@@ -218,7 +218,7 @@ func TestPresentationAPI(t *testing.T) {
 			}
 
 			value := newRequestValue(t, request)
-			createdID := storage2.SubmissionID(submissionOp.ID)
+			createdID := opstorage.SubmissionID(submissionOp.ID)
 			req := httptest.NewRequest(
 				http.MethodPut,
 				fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s/review", createdID),
@@ -243,7 +243,7 @@ func TestPresentationAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			createdID := storage2.SubmissionID(submissionOp.ID)
+			createdID := opstorage.SubmissionID(submissionOp.ID)
 			_ = reviewSubmission(t, pRouter, createdID)
 
 			request := router.ReviewSubmissionRequest{
@@ -323,14 +323,14 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           storage2.SubmissionID(op.ID),
+						ID:           opstorage.SubmissionID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           storage2.SubmissionID(op2.ID),
+						ID:           opstorage.SubmissionID(op2.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
@@ -395,7 +395,7 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           storage2.SubmissionID(op.ID),
+						ID:           opstorage.SubmissionID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	storage2 "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +21,6 @@ import (
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
-	"github.com/tbd54566975/ssi-service/pkg/service/operation"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation/model"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
@@ -163,14 +163,14 @@ func TestPresentationAPI(t *testing.T) {
 					"id":             "did:web:andresuribe.com",
 				})), holderDID, holderSigner)
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", operation.SubmissionID(op.ID)), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", storage2.SubmissionID(op.ID)), nil)
 			w := httptest.NewRecorder()
 
-			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": operation.SubmissionID(op.ID)}), w, req))
+			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": storage2.SubmissionID(op.ID)}), w, req))
 
 			var resp router.GetSubmissionResponse
 			assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-			assert.Equal(t, operation.SubmissionID(op.ID), resp.Submission.ID)
+			assert.Equal(t, storage2.SubmissionID(op.ID), resp.Submission.ID)
 			assert.Equal(t, definition.PresentationDefinition.ID, resp.Submission.DefinitionID)
 			assert.Equal(t, "pending", resp.Submission.Status)
 		})
@@ -218,7 +218,7 @@ func TestPresentationAPI(t *testing.T) {
 			}
 
 			value := newRequestValue(t, request)
-			createdID := operation.SubmissionID(submissionOp.ID)
+			createdID := storage2.SubmissionID(submissionOp.ID)
 			req := httptest.NewRequest(
 				http.MethodPut,
 				fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s/review", createdID),
@@ -243,7 +243,7 @@ func TestPresentationAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			createdID := operation.SubmissionID(submissionOp.ID)
+			createdID := storage2.SubmissionID(submissionOp.ID)
 			_ = reviewSubmission(t, pRouter, createdID)
 
 			request := router.ReviewSubmissionRequest{
@@ -323,14 +323,14 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           operation.SubmissionID(op.ID),
+						ID:           storage2.SubmissionID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           operation.SubmissionID(op2.ID),
+						ID:           storage2.SubmissionID(op2.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
@@ -395,7 +395,7 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           operation.SubmissionID(op.ID),
+						ID:           storage2.SubmissionID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/server/router"
-	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation/model"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
@@ -163,14 +163,14 @@ func TestPresentationAPI(t *testing.T) {
 					"id":             "did:web:andresuribe.com",
 				})), holderDID, holderSigner)
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", opstorage.SubmissionID(op.ID)), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", submission.ResourceID(op.ID)), nil)
 			w := httptest.NewRecorder()
 
-			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": opstorage.SubmissionID(op.ID)}), w, req))
+			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": submission.ResourceID(op.ID)}), w, req))
 
 			var resp router.GetSubmissionResponse
 			assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-			assert.Equal(t, opstorage.SubmissionID(op.ID), resp.Submission.ID)
+			assert.Equal(t, submission.ResourceID(op.ID), resp.Submission.ID)
 			assert.Equal(t, definition.PresentationDefinition.ID, resp.Submission.DefinitionID)
 			assert.Equal(t, "pending", resp.Submission.Status)
 		})
@@ -218,7 +218,7 @@ func TestPresentationAPI(t *testing.T) {
 			}
 
 			value := newRequestValue(t, request)
-			createdID := opstorage.SubmissionID(submissionOp.ID)
+			createdID := submission.ResourceID(submissionOp.ID)
 			req := httptest.NewRequest(
 				http.MethodPut,
 				fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s/review", createdID),
@@ -243,7 +243,7 @@ func TestPresentationAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			createdID := opstorage.SubmissionID(submissionOp.ID)
+			createdID := submission.ResourceID(submissionOp.ID)
 			_ = reviewSubmission(t, pRouter, createdID)
 
 			request := router.ReviewSubmissionRequest{
@@ -323,14 +323,14 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           opstorage.SubmissionID(op.ID),
+						ID:           submission.ResourceID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           opstorage.SubmissionID(op2.ID),
+						ID:           submission.ResourceID(op2.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
@@ -395,7 +395,7 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           opstorage.SubmissionID(op.ID),
+						ID:           submission.ResourceID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -163,14 +163,14 @@ func TestPresentationAPI(t *testing.T) {
 					"id":             "did:web:andresuribe.com",
 				})), holderDID, holderSigner)
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", submission.ResourceID(op.ID)), nil)
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s", submission.ID(op.ID)), nil)
 			w := httptest.NewRecorder()
 
-			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": submission.ResourceID(op.ID)}), w, req))
+			assert.NoError(t, pRouter.GetSubmission(newRequestContextWithParams(map[string]string{"id": submission.ID(op.ID)}), w, req))
 
 			var resp router.GetSubmissionResponse
 			assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-			assert.Equal(t, submission.ResourceID(op.ID), resp.Submission.ID)
+			assert.Equal(t, submission.ID(op.ID), resp.Submission.ID)
 			assert.Equal(t, definition.PresentationDefinition.ID, resp.Submission.DefinitionID)
 			assert.Equal(t, "pending", resp.Submission.Status)
 		})
@@ -218,7 +218,7 @@ func TestPresentationAPI(t *testing.T) {
 			}
 
 			value := newRequestValue(t, request)
-			createdID := submission.ResourceID(submissionOp.ID)
+			createdID := submission.ID(submissionOp.ID)
 			req := httptest.NewRequest(
 				http.MethodPut,
 				fmt.Sprintf("https://ssi-service.com/v1/presentations/submissions/%s/review", createdID),
@@ -243,7 +243,7 @@ func TestPresentationAPI(t *testing.T) {
 			holderSigner, holderDID := getSigner(t)
 			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, VerifiableCredential(), holderDID, holderSigner)
-			createdID := submission.ResourceID(submissionOp.ID)
+			createdID := submission.ID(submissionOp.ID)
 			_ = reviewSubmission(t, pRouter, createdID)
 
 			request := router.ReviewSubmissionRequest{
@@ -323,14 +323,14 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           submission.ResourceID(op.ID),
+						ID:           submission.ID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           submission.ResourceID(op2.ID),
+						ID:           submission.ID(op2.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},
@@ -395,7 +395,7 @@ func TestPresentationAPI(t *testing.T) {
 				{
 					Status: "pending",
 					PresentationSubmission: &exchange.PresentationSubmission{
-						ID:           submission.ResourceID(op.ID),
+						ID:           submission.ID(op.ID),
 						DefinitionID: definition.PresentationDefinition.ID,
 					},
 				},

--- a/pkg/service/operation/bolt.go
+++ b/pkg/service/operation/bolt.go
@@ -33,7 +33,7 @@ func NewBoltOperationStorage(db *storage.BoltDB) (*BoltOperationStorage, error) 
 func (b BoltOperationStorage) CancelOperation(id string) (*opstorage.StoredOperation, error) {
 	if strings.HasPrefix(id, submission.ParentResource) {
 		_, opData, err := b.db.UpdateValueAndOperation(
-			submission.Namespace, submission.ResourceID(id), storage.NewUpdater(map[string]any{
+			submission.Namespace, submission.ID(id), storage.NewUpdater(map[string]any{
 				"status": submission.StatusCancelled,
 				"reason": cancelledReason,
 			}),

--- a/pkg/service/operation/bolt.go
+++ b/pkg/service/operation/bolt.go
@@ -1,4 +1,4 @@
-package storage
+package operation
 
 import (
 	"strings"
@@ -7,65 +7,46 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tbd54566975/ssi-service/internal/util"
+	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage/namespace"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 	"go.einride.tech/aip/filtering"
 )
 
 const (
-	namespace           = "operation_submission"
-	SubmissionNamespace = "presentation_submission"
+	cancelledReason = "operation cancelled"
 )
-
-const SubmissionParentResource = "/presentations/submissions"
-
-// NamespaceFromID returns a namespace from a given operation ID. An empty string is returned when the namespace cannot
-// be determined.
-func NamespaceFromID(id string) string {
-	i := strings.LastIndex(id, "/")
-	if i == -1 {
-		return ""
-	}
-	return namespaceFromParent(id[:i])
-}
-
-func namespaceFromParent(parent string) string {
-	switch parent {
-	case SubmissionParentResource:
-		return namespace
-	default:
-		return ""
-	}
-}
 
 type BoltOperationStorage struct {
 	db *storage.BoltDB
 }
 
-func (b BoltOperationStorage) MarkDone(id string) (StoredOperation, error) {
-	if strings.HasPrefix(id, SubmissionParentResource) {
+func (b BoltOperationStorage) CancelOperation(id string) (opstorage.StoredOperation, error) {
+	if strings.HasPrefix(id, submission.ParentResource) {
 		_, opData, err := b.db.UpdateValueAndOperation(
-			SubmissionNamespace, SubmissionID(id), storage.NewUpdater(map[string]any{
-				"status": 2, // TODO: should we move status elsewhere, or pass this in?
-				"reason": "operation cancelled",
+			submission.Namespace, submission.ResourceID(id), storage.NewUpdater(map[string]any{
+				"status": submission.StatusCancelled,
+				"reason": cancelledReason,
 			}),
-			NamespaceFromID(id), id, OperationUpdater{
-				storage.NewUpdater(map[string]any{
+			namespace.FromID(id), id, submission.OperationUpdater{
+				UpdaterWithMap: storage.NewUpdater(map[string]any{
 					"done": true,
 				}),
 			})
 		if err != nil {
-			return StoredOperation{}, errors.Wrap(err, "updating value and op")
+			return opstorage.StoredOperation{}, errors.Wrap(err, "updating value and op")
 		}
-		var op StoredOperation
+		var op opstorage.StoredOperation
 		if err = json.Unmarshal(opData, &op); err != nil {
 			return op, errors.Wrap(err, "unmarshalling data")
 		}
 		return op, nil
 	}
-	return StoredOperation{}, errors.New("unrecognized id structure")
+	return opstorage.StoredOperation{}, errors.New("unrecognized id structure")
 }
 
-func (b BoltOperationStorage) StoreOperation(op StoredOperation) error {
+func (b BoltOperationStorage) StoreOperation(op opstorage.StoredOperation) error {
 	id := op.ID
 	if id == "" {
 		return util.LoggingNewError("ID is required for storing operations")
@@ -74,12 +55,12 @@ func (b BoltOperationStorage) StoreOperation(op StoredOperation) error {
 	if err != nil {
 		return util.LoggingErrorMsgf(err, "marshalling operation with id: %s", id)
 	}
-	return b.db.Write(NamespaceFromID(id), id, jsonBytes)
+	return b.db.Write(namespace.FromID(id), id, jsonBytes)
 }
 
-func (b BoltOperationStorage) GetOperation(id string) (StoredOperation, error) {
-	var stored StoredOperation
-	jsonBytes, err := b.db.Read(NamespaceFromID(id), id)
+func (b BoltOperationStorage) GetOperation(id string) (opstorage.StoredOperation, error) {
+	var stored opstorage.StoredOperation
+	jsonBytes, err := b.db.Read(namespace.FromID(id), id)
 	if err != nil {
 		return stored, util.LoggingErrorMsgf(err, "reading operation with id: %s", id)
 	}
@@ -92,8 +73,8 @@ func (b BoltOperationStorage) GetOperation(id string) (StoredOperation, error) {
 	return stored, nil
 }
 
-func (b BoltOperationStorage) GetOperations(parent string, filter filtering.Filter) ([]StoredOperation, error) {
-	operations, err := b.db.ReadAll(namespaceFromParent(parent))
+func (b BoltOperationStorage) GetOperations(parent string, filter filtering.Filter) ([]opstorage.StoredOperation, error) {
+	operations, err := b.db.ReadAll(namespace.FromParent(parent))
 	if err != nil {
 		return nil, util.LoggingErrorMsgf(err, "could not get all operations")
 	}
@@ -102,9 +83,9 @@ func (b BoltOperationStorage) GetOperations(parent string, filter filtering.Filt
 	if err != nil {
 		return nil, err
 	}
-	stored := make([]StoredOperation, 0, len(operations))
+	stored := make([]opstorage.StoredOperation, 0, len(operations))
 	for i, manifestBytes := range operations {
-		var nextOp StoredOperation
+		var nextOp opstorage.StoredOperation
 		if err = json.Unmarshal(manifestBytes, &nextOp); err != nil {
 			logrus.WithError(err).WithField("idx", i).Warnf("Skipping operation")
 		}
@@ -122,7 +103,7 @@ func (b BoltOperationStorage) GetOperations(parent string, filter filtering.Filt
 }
 
 func (b BoltOperationStorage) DeleteOperation(id string) error {
-	if err := b.db.Delete(NamespaceFromID(id), id); err != nil {
+	if err := b.db.Delete(namespace.FromID(id), id); err != nil {
 		return util.LoggingErrorMsgf(err, "deleting operation: %s", id)
 	}
 	return nil
@@ -134,4 +115,21 @@ func NewBoltOperationStorage(db *storage.BoltDB) (*BoltOperationStorage, error) 
 	}
 	return &BoltOperationStorage{db: db}, nil
 
+}
+
+func NewOperationStorage(s storage.ServiceStorage) (opstorage.Storage, error) {
+	switch s.Type() {
+	case storage.Bolt:
+		gotBolt, ok := s.(*storage.BoltDB)
+		if !ok {
+			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
+		}
+		boltStorage, err := NewBoltOperationStorage(gotBolt)
+		if err != nil {
+			return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
+		}
+		return boltStorage, err
+	default:
+		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
+	}
 }

--- a/pkg/service/operation/model.go
+++ b/pkg/service/operation/model.go
@@ -2,10 +2,9 @@ package operation
 
 import (
 	"fmt"
-	"strings"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 
 	"github.com/TBD54566975/ssi-sdk/util"
-	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"go.einride.tech/aip/filtering"
 )
 
@@ -18,16 +17,6 @@ type Operation struct {
 	ID     string `json:"json"`
 	Done   bool   `json:"done"`
 	Result Result `json:"result,omitempty"`
-}
-
-// SubmissionID attempts to parse the submission id from the ID of the operation. This is done by taking the last word
-// that results from splitting the id by "/". On failures, the empty string is returned.
-func SubmissionID(opID string) string {
-	i := strings.LastIndex(opID, "/")
-	if i == -1 {
-		return ""
-	}
-	return opID[(i + 1):]
 }
 
 type GetOperationsRequest struct {
@@ -49,6 +38,15 @@ type GetOperationRequest struct {
 
 // Validate does struct validation and returns an error when invalid.
 func (r GetOperationRequest) Validate() error {
+	return util.NewValidator().Struct(r)
+}
+
+type CancelOperationRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+// Validate does struct validation and returns an error when invalid.
+func (r CancelOperationRequest) Validate() error {
 	return util.NewValidator().Struct(r)
 }
 

--- a/pkg/service/operation/model.go
+++ b/pkg/service/operation/model.go
@@ -2,9 +2,9 @@ package operation
 
 import (
 	"fmt"
-	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 
 	"github.com/TBD54566975/ssi-sdk/util"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"go.einride.tech/aip/filtering"
 )
 

--- a/pkg/service/operation/model.go
+++ b/pkg/service/operation/model.go
@@ -1,10 +1,7 @@
 package operation
 
 import (
-	"fmt"
-
 	"github.com/TBD54566975/ssi-sdk/util"
-	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"go.einride.tech/aip/filtering"
 )
 
@@ -48,9 +45,4 @@ type CancelOperationRequest struct {
 // Validate does struct validation and returns an error when invalid.
 func (r CancelOperationRequest) Validate() error {
 	return util.NewValidator().Struct(r)
-}
-
-// IDFromSubmissionID returns a submission operation ID from the submission ID.
-func IDFromSubmissionID(id string) string {
-	return fmt.Sprintf("%s/%s", storage.SubmissionParentResource, id)
 }

--- a/pkg/service/operation/model_test.go
+++ b/pkg/service/operation/model_test.go
@@ -1,10 +1,10 @@
 package operation
 
 import (
-	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 )
 
 func TestSubmissionID(t *testing.T) {

--- a/pkg/service/operation/model_test.go
+++ b/pkg/service/operation/model_test.go
@@ -1,6 +1,7 @@
 package operation
 
 import (
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestSubmissionID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, SubmissionID(tt.opID))
+			assert.Equal(t, tt.want, storage.SubmissionID(tt.opID))
 		})
 	}
 }

--- a/pkg/service/operation/service.go
+++ b/pkg/service/operation/service.go
@@ -102,6 +102,18 @@ func (s Service) GetOperation(request GetOperationRequest) (Operation, error) {
 	return serviceModel(storedOp)
 }
 
+func (s Service) CancelOperation(request CancelOperationRequest) (Operation, error) {
+	if err := request.Validate(); err != nil {
+		return Operation{}, errors.Wrap(err, "invalid request")
+	}
+
+	storedOp, err := s.storage.MarkDone(request.ID)
+	if err != nil {
+		return Operation{}, errors.Wrap(err, "marking as done")
+	}
+	return serviceModel(storedOp)
+}
+
 func NewOperationService(s storage.ServiceStorage) (*Service, error) {
 	opStorage, err := opstorage.NewOperationStorage(s)
 	if err != nil {

--- a/pkg/service/operation/service.go
+++ b/pkg/service/operation/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tbd54566975/ssi-service/internal/util"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
 	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation/model"
 	prestorage "github.com/tbd54566975/ssi-service/pkg/service/presentation/storage"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
@@ -76,7 +77,7 @@ func serviceModel(op opstorage.StoredOperation) (Operation, error) {
 
 	if len(op.Response) > 0 {
 		switch {
-		case strings.HasPrefix(op.ID, opstorage.SubmissionParentResource):
+		case strings.HasPrefix(op.ID, submission.ParentResource):
 			var s prestorage.StoredSubmission
 			if err := json.Unmarshal(op.Response, &s); err != nil {
 				return Operation{}, err
@@ -107,7 +108,7 @@ func (s Service) CancelOperation(request CancelOperationRequest) (Operation, err
 		return Operation{}, errors.Wrap(err, "invalid request")
 	}
 
-	storedOp, err := s.storage.MarkDone(request.ID)
+	storedOp, err := s.storage.CancelOperation(request.ID)
 	if err != nil {
 		return Operation{}, errors.Wrap(err, "marking as done")
 	}
@@ -115,7 +116,7 @@ func (s Service) CancelOperation(request CancelOperationRequest) (Operation, err
 }
 
 func NewOperationService(s storage.ServiceStorage) (*Service, error) {
-	opStorage, err := opstorage.NewOperationStorage(s)
+	opStorage, err := NewOperationStorage(s)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "creating operation storage")
 	}

--- a/pkg/service/operation/service.go
+++ b/pkg/service/operation/service.go
@@ -112,7 +112,7 @@ func (s Service) CancelOperation(request CancelOperationRequest) (Operation, err
 	if err != nil {
 		return Operation{}, errors.Wrap(err, "marking as done")
 	}
-	return serviceModel(storedOp)
+	return serviceModel(*storedOp)
 }
 
 func NewOperationService(s storage.ServiceStorage) (*Service, error) {

--- a/pkg/service/operation/storage/bolt.go
+++ b/pkg/service/operation/storage/bolt.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	namespace = "operation_submission"
+	namespace           = "operation_submission"
+	SubmissionNamespace = "presentation_submission"
 )
 
 const SubmissionParentResource = "/presentations/submissions"

--- a/pkg/service/operation/storage/bolt.go
+++ b/pkg/service/operation/storage/bolt.go
@@ -52,6 +52,9 @@ func (b BoltOperationStorage) MarkDone(id string) (StoredOperation, error) {
 					"done": true,
 				}),
 			})
+		if err != nil {
+			return StoredOperation{}, errors.Wrap(err, "updating value and op")
+		}
 		var op StoredOperation
 		if err = json.Unmarshal(opData, &op); err != nil {
 			return op, errors.Wrap(err, "unmarshalling data")

--- a/pkg/service/operation/storage/namespace/namespace.go
+++ b/pkg/service/operation/storage/namespace/namespace.go
@@ -1,0 +1,30 @@
+package namespace
+
+import (
+	"strings"
+
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
+)
+
+const namespace = "operation_submission"
+
+// FromID returns a namespace from a given operation ID. An empty string is returned when the namespace cannot
+// be determined.
+func FromID(id string) string {
+	i := strings.LastIndex(id, "/")
+	if i == -1 {
+		return ""
+	}
+	return FromParent(id[:i])
+}
+
+// FromParent returns a namespace from a given parent resource name like "/presentations/submissions". Empty is returned
+// when the parent resource cannot be resolved.
+func FromParent(parent string) string {
+	switch parent {
+	case submission.ParentResource:
+		return namespace
+	default:
+		return ""
+	}
+}

--- a/pkg/service/operation/storage/storage.go
+++ b/pkg/service/operation/storage/storage.go
@@ -1,12 +1,13 @@
 package storage
 
 import (
+	"strings"
+
 	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
 	"github.com/tbd54566975/ssi-service/internal/util"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 	"go.einride.tech/aip/filtering"
-	"strings"
 )
 
 type StoredOperation struct {

--- a/pkg/service/operation/storage/storage.go
+++ b/pkg/service/operation/storage/storage.go
@@ -33,5 +33,5 @@ type Storage interface {
 	GetOperation(id string) (StoredOperation, error)
 	GetOperations(parent string, filter filtering.Filter) ([]StoredOperation, error)
 	DeleteOperation(id string) error
-	CancelOperation(id string) (StoredOperation, error)
+	CancelOperation(id string) (*StoredOperation, error)
 }

--- a/pkg/service/operation/storage/storage.go
+++ b/pkg/service/operation/storage/storage.go
@@ -1,12 +1,6 @@
 package storage
 
 import (
-	"strings"
-
-	"github.com/goccy/go-json"
-	"github.com/pkg/errors"
-	"github.com/tbd54566975/ssi-service/internal/util"
-	"github.com/tbd54566975/ssi-service/pkg/storage"
 	"go.einride.tech/aip/filtering"
 )
 
@@ -39,55 +33,5 @@ type Storage interface {
 	GetOperation(id string) (StoredOperation, error)
 	GetOperations(parent string, filter filtering.Filter) ([]StoredOperation, error)
 	DeleteOperation(id string) error
-	MarkDone(id string) (StoredOperation, error)
+	CancelOperation(id string) (StoredOperation, error)
 }
-
-func NewOperationStorage(s storage.ServiceStorage) (Storage, error) {
-	switch s.Type() {
-	case storage.Bolt:
-		gotBolt, ok := s.(*storage.BoltDB)
-		if !ok {
-			return nil, util.LoggingNewErrorf("trouble instantiating : %s", s.Type())
-		}
-		boltStorage, err := NewBoltOperationStorage(gotBolt)
-		if err != nil {
-			return nil, util.LoggingErrorMsg(err, "could not instantiate schema bolt storage")
-		}
-		return boltStorage, err
-	default:
-		return nil, util.LoggingNewErrorf("unsupported storage type: %s", s.Type())
-	}
-}
-
-// SubmissionID attempts to parse the submission id from the ID of the operation. This is done by taking the last word
-// that results from splitting the id by "/". On failures, the empty string is returned.
-func SubmissionID(opID string) string {
-	i := strings.LastIndex(opID, "/")
-	if i == -1 {
-		return ""
-	}
-	return opID[(i + 1):]
-}
-
-type OperationUpdater struct {
-	storage.UpdaterWithMap
-}
-
-func (u OperationUpdater) SetUpdatedResponse(response []byte) {
-	u.UpdaterWithMap.Values["response"] = response
-}
-
-func (u OperationUpdater) Validate(v []byte) error {
-	var op StoredOperation
-	if err := json.Unmarshal(v, &op); err != nil {
-		return errors.Wrap(err, "unmarshalling operation")
-	}
-
-	if op.Done {
-		return errors.New("operation already marked as done")
-	}
-
-	return nil
-}
-
-var _ storage.ResponseSettingUpdater = (*OperationUpdater)(nil)

--- a/pkg/service/operation/storage/storage.go
+++ b/pkg/service/operation/storage/storage.go
@@ -91,5 +91,3 @@ func (u OperationUpdater) Validate(v []byte) error {
 }
 
 var _ storage.ResponseSettingUpdater = (*OperationUpdater)(nil)
-
-const SubmissionNamespace = "presentation_submission"

--- a/pkg/service/operation/submission/submission.go
+++ b/pkg/service/operation/submission/submission.go
@@ -1,0 +1,83 @@
+package submission
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/pkg/errors"
+	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/storage"
+)
+
+// IDFromSubmissionID returns a submission operation ID from the submission ID.
+func IDFromSubmissionID(id string) string {
+	return fmt.Sprintf("%s/%s", ParentResource, id)
+}
+
+// ResourceID attempts to parse the submission id from the ID of the operation. This is done by taking the last word
+// that results from splitting the id by "/". On failures, the empty string is returned.
+func ResourceID(opID string) string {
+	i := strings.LastIndex(opID, "/")
+	if i == -1 {
+		return ""
+	}
+	return opID[(i + 1):]
+}
+
+// Namespace is the namespace to be used for storing submissions.
+const Namespace = "presentation_submission"
+
+// ParentResource is the prefix of the submission parent resource.
+const ParentResource = "/presentations/submissions"
+
+// Status indicates the current state of a submission.
+type Status uint8
+
+func (s Status) String() string {
+	switch s {
+	case StatusPending:
+		return "pending"
+	case StatusDenied:
+		return "denied"
+	case StatusApproved:
+		return "approved"
+	case StatusCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	StatusUnknown Status = iota
+	StatusPending
+	StatusCancelled
+	StatusDenied
+	StatusApproved
+)
+
+// OperationUpdater is an implementation of the storage.ResponseSettingUpdater. It's provides a way to update the
+// operation and submission within a single transaction.
+type OperationUpdater struct {
+	storage.UpdaterWithMap
+}
+
+func (u OperationUpdater) SetUpdatedResponse(response []byte) {
+	u.UpdaterWithMap.Values["response"] = response
+}
+
+func (u OperationUpdater) Validate(v []byte) error {
+	var op opstorage.StoredOperation
+	if err := json.Unmarshal(v, &op); err != nil {
+		return errors.Wrap(err, "unmarshalling operation")
+	}
+
+	if op.Done {
+		return errors.New("operation already marked as done")
+	}
+
+	return nil
+}
+
+var _ storage.ResponseSettingUpdater = (*OperationUpdater)(nil)

--- a/pkg/service/operation/submission/submission.go
+++ b/pkg/service/operation/submission/submission.go
@@ -15,9 +15,9 @@ func IDFromSubmissionID(id string) string {
 	return fmt.Sprintf("%s/%s", ParentResource, id)
 }
 
-// ResourceID attempts to parse the submission id from the ID of the operation. This is done by taking the last word
+// ID attempts to parse the submission id from the ID of the operation. This is done by taking the last word
 // that results from splitting the id by "/". On failures, the empty string is returned.
-func ResourceID(opID string) string {
+func ID(opID string) string {
 	i := strings.LastIndex(opID, "/")
 	if i == -1 {
 		return ""

--- a/pkg/service/operation/submission/submission.go
+++ b/pkg/service/operation/submission/submission.go
@@ -25,11 +25,12 @@ func ResourceID(opID string) string {
 	return opID[(i + 1):]
 }
 
-// Namespace is the namespace to be used for storing submissions.
-const Namespace = "presentation_submission"
-
-// ParentResource is the prefix of the submission parent resource.
-const ParentResource = "/presentations/submissions"
+const (
+	// Namespace is the namespace to be used for storing submissions.
+	Namespace = "presentation_submission"
+	// ParentResource is the prefix of the submission parent resource.
+	ParentResource = "/presentations/submissions"
+)
 
 // Status indicates the current state of a submission.
 type Status uint8
@@ -64,6 +65,9 @@ type OperationUpdater struct {
 }
 
 func (u OperationUpdater) SetUpdatedResponse(response []byte) {
+	if u.UpdaterWithMap.Values == nil {
+		return
+	}
 	u.UpdaterWithMap.Values["response"] = response
 }
 

--- a/pkg/service/operation/submission/submission_test.go
+++ b/pkg/service/operation/submission/submission_test.go
@@ -1,10 +1,9 @@
-package operation
+package submission
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 )
 
 func TestSubmissionID(t *testing.T) {
@@ -31,7 +30,7 @@ func TestSubmissionID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, storage.SubmissionID(tt.opID))
+			assert.Equal(t, tt.want, ResourceID(tt.opID))
 		})
 	}
 }

--- a/pkg/service/operation/submission/submission_test.go
+++ b/pkg/service/operation/submission/submission_test.go
@@ -30,7 +30,7 @@ func TestSubmissionID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, ResourceID(tt.opID))
+			assert.Equal(t, tt.want, ID(tt.opID))
 		})
 	}
 }

--- a/pkg/service/presentation/model/model.go
+++ b/pkg/service/presentation/model/model.go
@@ -67,7 +67,7 @@ type ListSubmissionRequest struct {
 }
 
 type Submission struct {
-	// One of {`pending`, `approved`, `denied`}.
+	// One of {`pending`, `approved`, `denied`, `cancelled`}.
 	Status string `json:"status" validate:"required"`
 	// The reason why the submission was approved or denied.
 	Reason string `json:"reason"`

--- a/pkg/service/presentation/service.go
+++ b/pkg/service/presentation/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
 	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/service/presentation/model"
 	presentationstorage "github.com/tbd54566975/ssi-service/pkg/service/presentation/storage"
 	"github.com/tbd54566975/ssi-service/pkg/service/schema"
@@ -58,7 +59,7 @@ func NewPresentationService(config config.PresentationServiceConfig, s storage.S
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not instantiate definition storage for the presentation service")
 	}
-	opsStorage, err := opstorage.NewOperationStorage(s)
+	opsStorage, err := operation.NewOperationStorage(s)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not instantiate storage for the operations")
 	}
@@ -177,7 +178,7 @@ func (s Service) CreateSubmission(request model.CreateSubmissionRequest) (*opera
 	}
 
 	storedSubmission := presentationstorage.StoredSubmission{
-		Status:     presentationstorage.StatusPending,
+		Status:     submission.StatusPending,
 		Submission: request.Submission,
 	}
 
@@ -186,7 +187,7 @@ func (s Service) CreateSubmission(request model.CreateSubmissionRequest) (*opera
 		return nil, errors.Wrap(err, "could not store presentation")
 	}
 
-	opID := operation.IDFromSubmissionID(storedSubmission.Submission.ID)
+	opID := submission.IDFromSubmissionID(storedSubmission.Submission.ID)
 	storedOp := opstorage.StoredOperation{
 		ID:   opID,
 		Done: false,
@@ -235,7 +236,7 @@ func (s Service) ReviewSubmission(request model.ReviewSubmissionRequest) (*model
 		return nil, errors.Wrap(err, "invalid request")
 	}
 
-	updatedSubmission, _, err := s.storage.UpdateSubmission(request.ID, request.Approved, request.Reason, operation.IDFromSubmissionID(request.ID))
+	updatedSubmission, _, err := s.storage.UpdateSubmission(request.ID, request.Approved, request.Reason, submission.IDFromSubmissionID(request.ID))
 	if err != nil {
 		return nil, errors.Wrap(err, "updating submission")
 	}

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -54,6 +54,8 @@ func (s Status) String() string {
 		return "denied"
 	case StatusApproved:
 		return "approved"
+	case StatusCancelled:
+		return "cancelled"
 	default:
 		return "unknown"
 	}
@@ -62,6 +64,7 @@ func (s Status) String() string {
 const (
 	StatusUnknown Status = iota
 	StatusPending
+	StatusCancelled
 	StatusDenied
 	StatusApproved
 )

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tbd54566975/ssi-service/internal/util"
 	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
+	"github.com/tbd54566975/ssi-service/pkg/service/operation/submission"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
 	"go.einride.tech/aip/filtering"
 )
@@ -44,33 +45,8 @@ func NewPresentationStorage(s storage.ServiceStorage) (Storage, error) {
 	}
 }
 
-type Status uint8
-
-func (s Status) String() string {
-	switch s {
-	case StatusPending:
-		return "pending"
-	case StatusDenied:
-		return "denied"
-	case StatusApproved:
-		return "approved"
-	case StatusCancelled:
-		return "cancelled"
-	default:
-		return "unknown"
-	}
-}
-
-const (
-	StatusUnknown Status = iota
-	StatusPending
-	StatusCancelled
-	StatusDenied
-	StatusApproved
-)
-
 type StoredSubmission struct {
-	Status     Status                          `json:"status"`
+	Status     submission.Status               `json:"status"`
 	Submission exchange.PresentationSubmission `json:"submission"`
 	Reason     string                          `json:"reason"`
 }


### PR DESCRIPTION
# Overview
This PR implements the `CancelOperation` endpoint.

# Description
After an operation is cancelled, the associated resource's status must be recorded. We currently only support operations related to `Submission` resources. In order to do so, this PR moved a number of methods around so there are no dependency cycles. The rule I followed was: submissions can depend on operations, but not the other way around. 

Happy to hear feedback about better organizing packages. 

# How Has This Been Tested?
See added unit tests. 

# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages

## References
SIP6
