### PR TITLE
[OSE-156] Scaffolding and API for issuance templates.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,17 @@ type ServerConfig struct {
 	EnableSchemaCaching bool          `toml:"enable_schema_caching" conf:"default:true"`
 }
 
+type IssuingServiceConfig struct {
+	*BaseServiceConfig
+}
+
+func (s *IssuingServiceConfig) IsEmpty() bool {
+	if s == nil {
+		return true
+	}
+	return reflect.DeepEqual(s, &IssuingServiceConfig{})
+}
+
 // ServicesConfig represents configurable properties for the components of the SSI Service
 type ServicesConfig struct {
 	// at present, it is assumed that a single storage provider works for all services
@@ -52,12 +63,13 @@ type ServicesConfig struct {
 	ServiceEndpoint string      `toml:"service_endpoint"`
 
 	// Embed all service-specific configs here. The order matters: from which should be instantiated first, to last
-	KeyStoreConfig     KeyStoreServiceConfig     `toml:"keystore,omitempty"`
-	DIDConfig          DIDServiceConfig          `toml:"did,omitempty"`
-	SchemaConfig       SchemaServiceConfig       `toml:"schema,omitempty"`
-	CredentialConfig   CredentialServiceConfig   `toml:"credential,omitempty"`
-	ManifestConfig     ManifestServiceConfig     `toml:"manifest,omitempty"`
-	PresentationConfig PresentationServiceConfig `toml:"presentation,omitempty"`
+	KeyStoreConfig       KeyStoreServiceConfig     `toml:"keystore,omitempty"`
+	DIDConfig            DIDServiceConfig          `toml:"did,omitempty"`
+	IssuingServiceConfig IssuingServiceConfig      `toml:"issuing,omitempty"`
+	SchemaConfig         SchemaServiceConfig       `toml:"schema,omitempty"`
+	CredentialConfig     CredentialServiceConfig   `toml:"credential,omitempty"`
+	ManifestConfig       ManifestServiceConfig     `toml:"manifest,omitempty"`
+	PresentationConfig   PresentationServiceConfig `toml:"presentation,omitempty"`
 }
 
 // BaseServiceConfig represents configurable properties for a specific component of the SSI Service
@@ -204,6 +216,9 @@ func LoadConfig(path string) (*SSIServiceConfig, error) {
 			},
 			PresentationConfig: PresentationServiceConfig{
 				BaseServiceConfig: &BaseServiceConfig{Name: "presentation"},
+			},
+			IssuingServiceConfig: IssuingServiceConfig{
+				BaseServiceConfig: &BaseServiceConfig{Name: "issuing"},
 			},
 		}
 	} else {

--- a/config/config.toml
+++ b/config/config.toml
@@ -36,6 +36,9 @@ resolution_methods = ["key", "web", "pkh", "peer"]
 [services.schema]
 name = "schema"
 
+[services.issuing]
+name = "issuing"
+
 [services.credential]
 name = "credential"
 

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -936,9 +936,13 @@ definitions:
   issuing.CreateIssuanceTemplateRequest:
     properties:
       id:
+        description: |-
+          ID to be used when creating the issuance template. Must be unique.
+          Required.
         type: string
       issuanceTemplate:
         $ref: '#/definitions/issuing.IssuanceTemplate'
+        description: The template to create.
     required:
     - id
     type: object
@@ -975,6 +979,7 @@ definitions:
     properties:
       issuanceTemplate:
         $ref: '#/definitions/issuing.IssuanceTemplate'
+        description: The template that was requested.
     type: object
   issuing.IssuanceTemplate:
     properties:
@@ -1768,7 +1773,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialsResponse'
+            $ref: '#/definitions/pkg_server_router.GetCredentialsResponse'
         "400":
           description: Bad request
           schema:
@@ -1790,14 +1795,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateCredentialRequest'
+          $ref: '#/definitions/pkg_server_router.CreateCredentialRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateCredentialResponse'
+            $ref: '#/definitions/pkg_server_router.CreateCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -1854,7 +1859,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialResponse'
+            $ref: '#/definitions/pkg_server_router.GetCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -1879,7 +1884,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialStatusResponse'
+            $ref: '#/definitions/pkg_server_router.GetCredentialStatusResponse'
         "400":
           description: Bad request
           schema:
@@ -1897,14 +1902,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.UpdateCredentialStatusRequest'
+          $ref: '#/definitions/pkg_server_router.UpdateCredentialStatusRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.UpdateCredentialStatusResponse'
+            $ref: '#/definitions/pkg_server_router.UpdateCredentialStatusResponse'
         "400":
           description: Bad request
           schema:
@@ -1933,7 +1938,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialStatusListResponse'
+            $ref: '#/definitions/pkg_server_router.GetCredentialStatusListResponse'
         "400":
           description: Bad request
           schema:
@@ -1952,14 +1957,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifyCredentialRequest'
+          $ref: '#/definitions/pkg_server_router.VerifyCredentialRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifyCredentialResponse'
+            $ref: '#/definitions/pkg_server_router.VerifyCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -2263,7 +2268,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetManifestsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetManifestsResponse'
         "400":
           description: Bad request
           schema:
@@ -2285,14 +2290,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateManifestRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateManifestRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.CreateManifestResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateManifestResponse'
         "400":
           description: Bad request
           schema:
@@ -2349,7 +2354,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetManifestResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetManifestResponse'
         "400":
           description: Bad request
           schema:
@@ -2369,7 +2374,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetApplicationsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetApplicationsResponse'
         "400":
           description: Bad request
           schema:
@@ -2392,7 +2397,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.SubmitApplicationRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.SubmitApplicationRequest'
       produces:
       - application/json
       responses:
@@ -2400,7 +2405,7 @@ paths:
           description: Operation with a SubmitApplicationResponse type in the `result.response`
             field.
           schema:
-            $ref: '#/definitions/pkg_server_router.Operation'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.Operation'
         "400":
           description: Bad request
           schema:
@@ -2457,7 +2462,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetApplicationResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetApplicationResponse'
         "400":
           description: Bad request
           schema:
@@ -2477,7 +2482,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetResponsesResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetResponsesResponse'
         "400":
           description: Bad request
           schema:
@@ -2534,7 +2539,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetResponseResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetResponseResponse'
         "400":
           description: Bad request
           schema:
@@ -2553,14 +2558,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetOperationsRequest'
+          $ref: '#/definitions/pkg_server_router.GetOperationsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetOperationsResponse'
+            $ref: '#/definitions/pkg_server_router.GetOperationsResponse'
         "400":
           description: Bad request
           schema:
@@ -2589,7 +2594,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.Operation'
+            $ref: '#/definitions/pkg_server_router.Operation'
         "400":
           description: Bad request
           schema:
@@ -2618,7 +2623,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.Operation'
+            $ref: '#/definitions/pkg_server_router.Operation'
         "400":
           description: Bad request
           schema:
@@ -2841,7 +2846,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetSchemasResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemasResponse'
         "500":
           description: Internal server error
           schema:
@@ -2859,14 +2864,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateSchemaRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.CreateSchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2923,7 +2928,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetSchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2942,14 +2947,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.VerifySchemaRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.VerifySchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaResponse'
         "400":
           description: Bad request
           schema:

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -523,6 +523,21 @@ definitions:
       privateKeyBase58:
         type: string
     type: object
+  github.com_tbd54566975_ssi-service_pkg_server_router.CreateIssuanceTemplateRequest:
+    properties:
+      credentialManifest:
+        description: ID of the credential manifest that this template corresponds
+          to.
+        type: string
+      credentials:
+        description: Info required to create a credential from a credential application.
+        items:
+          $ref: '#/definitions/issuing.CredentialTemplate'
+        type: array
+      issuer:
+        description: ID of the issuer that will be issuing the credentials.
+        type: string
+    type: object
   github.com_tbd54566975_ssi-service_pkg_server_router.CreateManifestRequest:
     properties:
       description:
@@ -933,19 +948,6 @@ definitions:
           claim about the credentialSubject in the credential that will be issued.
         type: object
     type: object
-  issuing.CreateIssuanceTemplateRequest:
-    properties:
-      id:
-        description: |-
-          ID to be used when creating the issuance template. Must be unique.
-          Required.
-        type: string
-      issuanceTemplate:
-        $ref: '#/definitions/issuing.IssuanceTemplate'
-        description: The template to create.
-    required:
-    - id
-    type: object
   issuing.CredentialTemplate:
     properties:
       data:
@@ -1189,6 +1191,21 @@ definitions:
       keyType:
         type: string
       privateKeyBase58:
+        type: string
+    type: object
+  pkg_server_router.CreateIssuanceTemplateRequest:
+    properties:
+      credentialManifest:
+        description: ID of the credential manifest that this template corresponds
+          to.
+        type: string
+      credentials:
+        description: Info required to create a credential from a credential application.
+        items:
+          $ref: '#/definitions/issuing.CredentialTemplate'
+        type: array
+      issuer:
+        description: ID of the issuer that will be issuing the credentials.
         type: string
     type: object
   pkg_server_router.CreateManifestRequest:
@@ -2118,7 +2135,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/issuing.CreateIssuanceTemplateRequest'
+          $ref: '#/definitions/pkg_server_router.CreateIssuanceTemplateRequest'
       produces:
       - application/json
       responses:
@@ -2201,7 +2218,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.StoreKeyRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.StoreKeyRequest'
       produces:
       - application/json
       responses:
@@ -2235,7 +2252,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetKeyDetailsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetKeyDetailsResponse'
         "400":
           description: Bad request
           schema:
@@ -2846,7 +2863,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemasResponse'
+            $ref: '#/definitions/pkg_server_router.GetSchemasResponse'
         "500":
           description: Internal server error
           schema:
@@ -2864,14 +2881,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaRequest'
+          $ref: '#/definitions/pkg_server_router.CreateSchemaRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaResponse'
+            $ref: '#/definitions/pkg_server_router.CreateSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2928,7 +2945,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemaResponse'
+            $ref: '#/definitions/pkg_server_router.GetSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2947,14 +2964,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaRequest'
+          $ref: '#/definitions/pkg_server_router.VerifySchemaRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaResponse'
+            $ref: '#/definitions/pkg_server_router.VerifySchemaResponse'
         "400":
           description: Bad request
           schema:

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -924,7 +924,14 @@ definitions:
       verified:
         type: boolean
     type: object
-  issuing.Claims:
+  issuing.ClaimTemplates:
+    properties:
+      data:
+        additionalProperties: {}
+        description: |-
+          Values may be json path like strings, or any other JSON primitive. Each entry will be used to come up with a
+          claim about the credentialSubject in the credential that will be issued.
+        type: object
     type: object
   issuing.CreateIssuanceTemplateRequest:
     properties:
@@ -935,24 +942,33 @@ definitions:
     required:
     - id
     type: object
-  issuing.Credential:
+  issuing.CredentialTemplate:
     properties:
       data:
-        $ref: '#/definitions/issuing.CredentialData'
+        $ref: '#/definitions/issuing.CredentialTemplateData'
+        description: Date that will be used to determine credential claims.
       expiry:
         $ref: '#/definitions/issuing.TimeLike'
+        description: Parameter to determine the expiry of the credential.
       id:
+        description: ID corresponding to an OutputDescriptor.ID from the manifest.
         type: string
       revocable:
+        description: Whether the credentials created should be revocable.
         type: boolean
       schema:
+        description: ID of the CredentialSchema to be used for the issued credential.
         type: string
     type: object
-  issuing.CredentialData:
+  issuing.CredentialTemplateData:
     properties:
       claims:
-        $ref: '#/definitions/issuing.Claims'
+        $ref: '#/definitions/issuing.ClaimTemplates'
+        description: The set of information that will be used to create claims.
       credentialInputDescriptor:
+        description: |-
+          ID of the input descriptor in the application. Correponds to one of the
+          PresentationDefinition.InputDescriptors[].ID in the credential manifest.
         type: string
     type: object
   issuing.GetIssuanceTemplateResponse:
@@ -963,12 +979,16 @@ definitions:
   issuing.IssuanceTemplate:
     properties:
       credentialManifest:
+        description: ID of the credential manifest that this template corresponds
+          to.
         type: string
       credentials:
+        description: Info required to create a credential from a credential application.
         items:
-          $ref: '#/definitions/issuing.Credential'
+          $ref: '#/definitions/issuing.CredentialTemplate'
         type: array
       issuer:
+        description: ID of the issuer that will be issuing the credentials.
         type: string
     type: object
   issuing.TimeLike:
@@ -1702,7 +1722,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetHealthCheckResponse'
+            $ref: '#/definitions/pkg_server_router.GetHealthCheckResponse'
       summary: Health Check
       tags:
       - HealthCheck
@@ -1958,7 +1978,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDMethodsResponse'
+            $ref: '#/definitions/pkg_server_router.GetDIDMethodsResponse'
       summary: Get DID Methods
       tags:
       - DecentralizedIdentityAPI
@@ -1979,7 +1999,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDsByMethodResponse'
+            $ref: '#/definitions/pkg_server_router.GetDIDsByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -1997,7 +2017,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodRequest'
+          $ref: '#/definitions/pkg_server_router.CreateDIDByMethodRequest'
       - description: Method
         in: path
         name: method
@@ -2009,7 +2029,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodResponse'
+            $ref: '#/definitions/pkg_server_router.CreateDIDByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -2032,7 +2052,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodRequest'
+          $ref: '#/definitions/pkg_server_router.CreateDIDByMethodRequest'
       - description: Method
         in: path
         name: method
@@ -2049,7 +2069,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDByMethodResponse'
+            $ref: '#/definitions/pkg_server_router.GetDIDByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -2074,7 +2094,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.ResolveDIDResponse'
+            $ref: '#/definitions/pkg_server_router.ResolveDIDResponse'
         "400":
           description: Bad request
           schema:
@@ -2140,7 +2160,7 @@ paths:
             type: string
       summary: Delete issuance template
       tags:
-      - IssuanceAPI
+      - IssuingAPI
     get:
       consumes:
       - application/json
@@ -2176,7 +2196,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.StoreKeyRequest'
+          $ref: '#/definitions/pkg_server_router.StoreKeyRequest'
       produces:
       - application/json
       responses:
@@ -2210,7 +2230,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetKeyDetailsResponse'
+            $ref: '#/definitions/pkg_server_router.GetKeyDetailsResponse'
         "400":
           description: Bad request
           schema:
@@ -2821,7 +2841,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemasResponse'
+            $ref: '#/definitions/pkg_server_router.GetSchemasResponse'
         "500":
           description: Internal server error
           schema:
@@ -2839,14 +2859,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaRequest'
+          $ref: '#/definitions/pkg_server_router.CreateSchemaRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaResponse'
+            $ref: '#/definitions/pkg_server_router.CreateSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2903,7 +2923,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemaResponse'
+            $ref: '#/definitions/pkg_server_router.GetSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2922,14 +2942,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaRequest'
+          $ref: '#/definitions/pkg_server_router.VerifySchemaRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaResponse'
+            $ref: '#/definitions/pkg_server_router.VerifySchemaResponse'
         "400":
           description: Bad request
           schema:

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -778,6 +778,13 @@ definitions:
     - id
     - status
     type: object
+  github.com_tbd54566975_ssi-service_pkg_server_router.ListIssuanceTemplatesResponse:
+    properties:
+      issuanceTemplates:
+        items:
+          $ref: '#/definitions/issuing.IssuanceTemplate'
+        type: array
+    type: object
   github.com_tbd54566975_ssi-service_pkg_server_router.ListSubmissionRequest:
     properties:
       filter:
@@ -803,7 +810,7 @@ definitions:
         type: string
       result:
         $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.OperationResult'
-        description: Populated Done == true.
+        description: Populated if Done == true.
     type: object
   github.com_tbd54566975_ssi-service_pkg_server_router.OperationResult:
     properties:
@@ -916,6 +923,60 @@ definitions:
         type: string
       verified:
         type: boolean
+    type: object
+  issuing.Claims:
+    type: object
+  issuing.CreateIssuanceTemplateRequest:
+    properties:
+      id:
+        type: string
+      issuanceTemplate:
+        $ref: '#/definitions/issuing.IssuanceTemplate'
+    required:
+    - id
+    type: object
+  issuing.Credential:
+    properties:
+      data:
+        $ref: '#/definitions/issuing.CredentialData'
+      expiry:
+        $ref: '#/definitions/issuing.TimeLike'
+      id:
+        type: string
+      revocable:
+        type: boolean
+      schema:
+        type: string
+    type: object
+  issuing.CredentialData:
+    properties:
+      claims:
+        $ref: '#/definitions/issuing.Claims'
+      credentialInputDescriptor:
+        type: string
+    type: object
+  issuing.GetIssuanceTemplateResponse:
+    properties:
+      issuanceTemplate:
+        $ref: '#/definitions/issuing.IssuanceTemplate'
+    type: object
+  issuing.IssuanceTemplate:
+    properties:
+      credentialManifest:
+        type: string
+      credentials:
+        items:
+          $ref: '#/definitions/issuing.Credential'
+        type: array
+      issuer:
+        type: string
+    type: object
+  issuing.TimeLike:
+    properties:
+      time.Duration:
+        type: integer
+      time.Time:
+        type: string
     type: object
   manifest.CredentialApplication:
     properties:
@@ -1360,6 +1421,13 @@ definitions:
     - id
     - status
     type: object
+  pkg_server_router.ListIssuanceTemplatesResponse:
+    properties:
+      issuanceTemplates:
+        items:
+          $ref: '#/definitions/issuing.IssuanceTemplate'
+        type: array
+    type: object
   pkg_server_router.ListSubmissionRequest:
     properties:
       filter:
@@ -1385,7 +1453,7 @@ definitions:
         type: string
       result:
         $ref: '#/definitions/pkg_server_router.OperationResult'
-        description: Populated Done == true.
+        description: Populated if Done == true.
     type: object
   pkg_server_router.OperationResult:
     properties:
@@ -1634,7 +1702,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetHealthCheckResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetHealthCheckResponse'
       summary: Health Check
       tags:
       - HealthCheck
@@ -1680,7 +1748,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetCredentialsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialsResponse'
         "400":
           description: Bad request
           schema:
@@ -1702,14 +1770,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateCredentialRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateCredentialRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.CreateCredentialResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -1766,7 +1834,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetCredentialResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -1791,7 +1859,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetCredentialStatusResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialStatusResponse'
         "400":
           description: Bad request
           schema:
@@ -1809,14 +1877,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.UpdateCredentialStatusRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.UpdateCredentialStatusRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.UpdateCredentialStatusResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.UpdateCredentialStatusResponse'
         "400":
           description: Bad request
           schema:
@@ -1845,7 +1913,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetCredentialStatusListResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetCredentialStatusListResponse'
         "400":
           description: Bad request
           schema:
@@ -1864,14 +1932,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.VerifyCredentialRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifyCredentialRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.VerifyCredentialResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifyCredentialResponse'
         "400":
           description: Bad request
           schema:
@@ -1890,7 +1958,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetDIDMethodsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDMethodsResponse'
       summary: Get DID Methods
       tags:
       - DecentralizedIdentityAPI
@@ -1911,7 +1979,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetDIDsByMethodResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDsByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -1929,7 +1997,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateDIDByMethodRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodRequest'
       - description: Method
         in: path
         name: method
@@ -1941,7 +2009,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.CreateDIDByMethodResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -1964,7 +2032,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateDIDByMethodRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateDIDByMethodRequest'
       - description: Method
         in: path
         name: method
@@ -1981,7 +2049,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetDIDByMethodResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetDIDByMethodResponse'
         "400":
           description: Bad request
           schema:
@@ -2006,7 +2074,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.ResolveDIDResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.ResolveDIDResponse'
         "400":
           description: Bad request
           schema:
@@ -2014,6 +2082,89 @@ paths:
       summary: Resolve a DID
       tags:
       - DecentralizedIdentityAPI
+  /v1/issuancetemplates:
+    put:
+      consumes:
+      - application/json
+      description: Create issuance template
+      parameters:
+      - description: request body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/issuing.CreateIssuanceTemplateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/issuing.IssuanceTemplate'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Create issuance template
+      tags:
+      - IssuingAPI
+  /v1/issuancetemplates/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete issuance template by ID
+      parameters:
+      - description: ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Delete issuance template
+      tags:
+      - IssuanceAPI
+    get:
+      consumes:
+      - application/json
+      description: Get an issuance template by its id
+      parameters:
+      - description: ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/issuing.GetIssuanceTemplateResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+      summary: Get issuance template
+      tags:
+      - IssuingAPI
   /v1/keys:
     put:
       consumes:
@@ -2025,7 +2176,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.StoreKeyRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.StoreKeyRequest'
       produces:
       - application/json
       responses:
@@ -2059,7 +2210,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetKeyDetailsResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetKeyDetailsResponse'
         "400":
           description: Bad request
           schema:
@@ -2670,7 +2821,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetSchemasResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemasResponse'
         "500":
           description: Internal server error
           schema:
@@ -2688,14 +2839,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.CreateSchemaRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/pkg_server_router.CreateSchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.CreateSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2752,7 +2903,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.GetSchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.GetSchemaResponse'
         "400":
           description: Bad request
           schema:
@@ -2771,14 +2922,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/pkg_server_router.VerifySchemaRequest'
+          $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/pkg_server_router.VerifySchemaResponse'
+            $ref: '#/definitions/github.com_tbd54566975_ssi-service_pkg_server_router.VerifySchemaResponse'
         "400":
           description: Bad request
           schema:

--- a/pkg/server/router/issuance.go
+++ b/pkg/server/router/issuance.go
@@ -53,7 +53,7 @@ func (ir IssuanceRouter) CreateIssuanceTemplate(ctx context.Context, w http.Resp
 // DeleteIssuanceTemplate godoc
 // @Summary      Delete issuance template
 // @Description  Delete issuance template by ID
-// @Tags         IssuanceAPI
+// @Tags         IssuingAPI
 // @Accept       json
 // @Produce      json
 // @Param        id   path      string  true  "ID"
@@ -72,7 +72,7 @@ type ListIssuanceTemplatesResponse struct {
 // ListIssuanceTemplates godoc
 // @Summary      Lists issuance templates
 // @Description  Lists all issuangce templates stored in this service.
-// @Tags         IssuanceAPI
+// @Tags         IssuingAPI
 // @Accept       json
 // @Produce      json
 // @Success      200      {object}  ListIssuanceTemplatesResponse

--- a/pkg/server/router/issuance.go
+++ b/pkg/server/router/issuance.go
@@ -1,0 +1,84 @@
+package router
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/tbd54566975/ssi-service/pkg/service/framework"
+	"github.com/tbd54566975/ssi-service/pkg/service/issuing"
+)
+
+type IssuanceRouter struct {
+	service issuing.Service
+}
+
+func NewIssuanceRouter(svc framework.Service) (*IssuanceRouter, error) {
+	service, ok := svc.(*issuing.Service)
+	if !ok {
+		return nil, errors.New("could not cast to issuing service type")
+	}
+	return &IssuanceRouter{service: *service}, nil
+}
+
+// GetIssuanceTemplate godoc
+// @Summary      Get issuance template
+// @Description  Get an issuance template by its id
+// @Tags         IssuingAPI
+// @Accept       json
+// @Produce      json
+// @Param        id   path      string  true  "ID"
+// @Success      200  {object}  issuing.GetIssuanceTemplateResponse
+// @Failure      400  {string}  string  "Bad request"
+// @Router       /v1/issuancetemplates/{id} [get]
+func (ir IssuanceRouter) GetIssuanceTemplate(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	return nil
+}
+
+// CreateIssuanceTemplate godoc
+// @Summary      Create issuance template
+// @Description  Create issuance template
+// @Tags         IssuingAPI
+// @Accept       json
+// @Produce      json
+// @Param        request  body      issuing.CreateIssuanceTemplateRequest  true  "request body"
+// @Success      201      {object}  issuing.IssuanceTemplate
+// @Failure      400      {string}  string  "Bad request"
+// @Failure      500      {string}  string  "Internal server error"
+// @Router       /v1/issuancetemplates [put]
+func (ir IssuanceRouter) CreateIssuanceTemplate(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// DeleteIssuanceTemplate godoc
+// @Summary      Delete issuance template
+// @Description  Delete issuance template by ID
+// @Tags         IssuanceAPI
+// @Accept       json
+// @Produce      json
+// @Param        id   path      string  true  "ID"
+// @Success      200  {string}  string  "OK"
+// @Failure      400  {string}  string  "Bad request"
+// @Failure      500  {string}  string  "Internal server error"
+// @Router       /v1/issuancetemplates/{id} [delete]
+func (ir IssuanceRouter) DeleteIssuanceTemplate(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+type ListIssuanceTemplatesResponse struct {
+	IssuanceTemplates []issuing.IssuanceTemplate `json:"issuanceTemplates"`
+}
+
+// ListIssuanceTemplates godoc
+// @Summary      Lists issuance templates
+// @Description  Lists all issuangce templates stored in this service.
+// @Tags         IssuanceAPI
+// @Accept       json
+// @Produce      json
+// @Success      200      {object}  ListIssuanceTemplatesResponse
+// @Failure      400      {string}  string  "Bad request"
+// @Failure      500      {string}  string  "Internal server error"
+// @Router       /v1/manifests [get]
+func (ir IssuanceRouter) ListIssuanceTemplates(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/pkg/server/router/issuance.go
+++ b/pkg/server/router/issuance.go
@@ -35,13 +35,17 @@ func (ir IssuanceRouter) GetIssuanceTemplate(ctx context.Context, w http.Respons
 	return nil
 }
 
+type CreateIssuanceTemplateRequest struct {
+	issuing.IssuanceTemplate
+}
+
 // CreateIssuanceTemplate godoc
 // @Summary      Create issuance template
 // @Description  Create issuance template
 // @Tags         IssuingAPI
 // @Accept       json
 // @Produce      json
-// @Param        request  body      issuing.CreateIssuanceTemplateRequest  true  "request body"
+// @Param        request  body      CreateIssuanceTemplateRequest  true  "request body"
 // @Success      201      {object}  issuing.IssuanceTemplate
 // @Failure      400      {string}  string  "Bad request"
 // @Failure      500      {string}  string  "Internal server error"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,23 +20,24 @@ import (
 )
 
 const (
-	HealthPrefix        = "/health"
-	ReadinessPrefix     = "/readiness"
-	V1Prefix            = "/v1"
-	OperationPrefix     = "/operations"
-	DIDsPrefix          = "/dids"
-	ResolverPrefix      = "/resolver"
-	SchemasPrefix       = "/schemas"
-	CredentialsPrefix   = "/credentials"
-	StatusPrefix        = "/status"
-	PresentationsPrefix = "/presentations"
-	DefinitionsPrefix   = "/definitions"
-	SubmissionsPrefix   = "/submissions"
-	ManifestsPrefix     = "/manifests"
-	ApplicationsPrefix  = "/applications"
-	ResponsesPrefix     = "/responses"
-	KeyStorePrefix      = "/keys"
-	VerificationPath    = "/verification"
+	HealthPrefix           = "/health"
+	ReadinessPrefix        = "/readiness"
+	V1Prefix               = "/v1"
+	OperationPrefix        = "/operations"
+	DIDsPrefix             = "/dids"
+	ResolverPrefix         = "/resolver"
+	SchemasPrefix          = "/schemas"
+	CredentialsPrefix      = "/credentials"
+	StatusPrefix           = "/status"
+	PresentationsPrefix    = "/presentations"
+	DefinitionsPrefix      = "/definitions"
+	SubmissionsPrefix      = "/submissions"
+	IssuanceTemplatePrefix = "/issuancetemplates"
+	ManifestsPrefix        = "/manifests"
+	ApplicationsPrefix     = "/applications"
+	ResponsesPrefix        = "/responses"
+	KeyStorePrefix         = "/keys"
+	VerificationPath       = "/verification"
 )
 
 // SSIServer exposes all dependencies needed to run a http server and all its services
@@ -107,6 +108,8 @@ func (s *SSIServer) instantiateRouter(service svcframework.Service) error {
 		return s.PresentationAPI(service)
 	case svcframework.Operation:
 		return s.OperationAPI(service)
+	case svcframework.Issuing:
+		return s.IssuanceAPI(service)
 	default:
 		return fmt.Errorf("could not instantiate API for service: %s", serviceType)
 	}
@@ -247,4 +250,18 @@ func (s *SSIServer) ManifestAPI(service svcframework.Service) (err error) {
 	s.Handle(http.MethodGet, path.Join(responsesHandlerPath, "/:id"), manifestRouter.GetResponse)
 	s.Handle(http.MethodDelete, path.Join(responsesHandlerPath, "/:id"), manifestRouter.DeleteResponse)
 	return
+}
+
+func (s *SSIServer) IssuanceAPI(service svcframework.Service) error {
+	issuanceRouter, err := router.NewIssuanceRouter(service)
+	if err != nil {
+		return util.LoggingErrorMsg(err, "could not create issuance router")
+	}
+
+	issuanceHandlerPath := V1Prefix + IssuanceTemplatePrefix
+	s.Handle(http.MethodPut, issuanceHandlerPath, issuanceRouter.CreateIssuanceTemplate)
+	s.Handle(http.MethodGet, issuanceHandlerPath, issuanceRouter.ListIssuanceTemplates)
+	s.Handle(http.MethodGet, path.Join(issuanceHandlerPath, "/:id"), issuanceRouter.GetIssuanceTemplate)
+	s.Handle(http.MethodDelete, path.Join(issuanceHandlerPath, "/:id"), issuanceRouter.DeleteIssuanceTemplate)
+	return nil
 }

--- a/pkg/service/framework/framework.go
+++ b/pkg/service/framework/framework.go
@@ -10,6 +10,7 @@ const (
 
 	DID          Type = "did"
 	Schema       Type = "schema"
+	Issuing      Type = "issuing"
 	Credential   Type = "credential"
 	KeyStore     Type = "keystore"
 	Manifest     Type = "manifest"

--- a/pkg/service/issuing/model.go
+++ b/pkg/service/issuing/model.go
@@ -1,0 +1,108 @@
+package issuing
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tbd54566975/ssi-service/config"
+	"github.com/tbd54566975/ssi-service/pkg/service/framework"
+	"github.com/tbd54566975/ssi-service/pkg/storage"
+)
+
+type GetIssuanceTemplateRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+type CredentialData struct {
+	CredentialInputDescriptor string `json:"credentialInputDescriptor"`
+	Claims                    Claims
+}
+
+type TimeLike struct {
+	// For fixed time in the future.
+	*time.Time
+
+	// For a fixed offset from when it was issued.
+	*time.Duration
+}
+
+type Claims struct {
+	// Values may be json path like strings, or any other JSON primitive.
+	Data map[string]any
+}
+
+type Credential struct {
+	ID        string         `json:"id"`
+	Schema    string         `json:"schema"`
+	Data      CredentialData `json:"data"`
+	Expiry    TimeLike       `json:"expiry"`
+	Revocable bool           `json:"revocable"`
+}
+
+type IssuanceTemplate struct {
+	CredentialManifest string       `json:"credentialManifest"`
+	Issuer             string       `json:"issuer"`
+	Credentials        []Credential `json:"credentials"`
+}
+
+type GetIssuanceTemplateResponse struct {
+	IssuanceTemplate IssuanceTemplate `json:"issuanceTemplate"`
+}
+
+type CreateIssuanceTemplateRequest struct {
+	ID               string           `json:"id" validate:"required"`
+	IssuanceTemplate IssuanceTemplate `json:"issuanceTemplate"`
+}
+
+type DeleteIssuanceTemplateRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+type Service struct {
+	config  config.IssuingServiceConfig
+	storage Storage
+}
+
+func (s *Service) Type() framework.Type {
+	return framework.Issuing
+}
+
+func (s *Service) Status() framework.Status {
+	return framework.Status{Status: framework.StatusReady}
+}
+
+func NewIssuingService(config config.IssuingServiceConfig, s storage.ServiceStorage) (*Service, error) {
+	issuingStorage, err := NewIssuingStorage(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating issuing storage")
+	}
+	return &Service{
+		storage: *issuingStorage,
+		config:  config,
+	}, nil
+}
+
+type Storage struct {
+	db storage.ServiceStorage
+}
+
+func NewIssuingStorage(s storage.ServiceStorage) (*Storage, error) {
+	if s == nil {
+		return nil, errors.New("s cannot be nil")
+	}
+	return &Storage{
+		db: s,
+	}, nil
+}
+
+func (s *Service) GetIssuanceTemplate(request *GetIssuanceTemplateRequest) (*GetIssuanceTemplateResponse, error) {
+	return nil, nil
+}
+
+func (s *Service) CreateIssuanceTemplate(request *CreateIssuanceTemplateRequest) (*IssuanceTemplate, error) {
+	return nil, nil
+}
+
+func (s *Service) DeleteIssuanceTemplate(request *DeleteIssuanceTemplateRequest) error {
+	return nil
+}

--- a/pkg/service/issuing/model.go
+++ b/pkg/service/issuing/model.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
 	"github.com/tbd54566975/ssi-service/pkg/storage"
+	"go.einride.tech/aip/filtering"
 )
 
 type GetIssuanceTemplateRequest struct {
@@ -65,16 +66,33 @@ type IssuanceTemplate struct {
 }
 
 type GetIssuanceTemplateResponse struct {
+	// The template that was requested.
 	IssuanceTemplate IssuanceTemplate `json:"issuanceTemplate"`
 }
 
 type CreateIssuanceTemplateRequest struct {
-	ID               string           `json:"id" validate:"required"`
+	// ID to be used when creating the issuance template. Must be unique.
+	// Required.
+	ID string `json:"id" validate:"required"`
+
+	// The template to create.
 	IssuanceTemplate IssuanceTemplate `json:"issuanceTemplate"`
 }
 
 type DeleteIssuanceTemplateRequest struct {
+	// ID of the template that will be deleted.
+	// Required.
 	ID string `json:"id" validate:"required"`
+}
+
+type ListIssuanceTemplatesRequest struct {
+	// A parsed filter expression conforming to https://google.aip.dev/160.
+	Filter filtering.Filter
+}
+
+type ListIssuanceTemplatesResponse struct {
+	// The issuance templates that satisfy the query conditions.
+	IssuanceTemplates []IssuanceTemplate `json:"issuanceTemplates"`
 }
 
 type Service struct {
@@ -124,4 +142,8 @@ func (s *Service) CreateIssuanceTemplate(request *CreateIssuanceTemplateRequest)
 
 func (s *Service) DeleteIssuanceTemplate(request *DeleteIssuanceTemplateRequest) error {
 	return nil
+}
+
+func (s *Service) ListIssuanceTemplates(request *ListIssuanceTemplatesRequest) (*ListIssuanceTemplatesResponse, error) {
+	return nil, nil
 }

--- a/pkg/service/issuing/model.go
+++ b/pkg/service/issuing/model.go
@@ -13,9 +13,13 @@ type GetIssuanceTemplateRequest struct {
 	ID string `json:"id" validate:"required"`
 }
 
-type CredentialData struct {
+type CredentialTemplateData struct {
+	// ID of the input descriptor in the application. Correponds to one of the
+	// PresentationDefinition.InputDescriptors[].ID in the credential manifest.
 	CredentialInputDescriptor string `json:"credentialInputDescriptor"`
-	Claims                    Claims
+
+	// The set of information that will be used to create claims.
+	Claims ClaimTemplates
 }
 
 type TimeLike struct {
@@ -26,23 +30,38 @@ type TimeLike struct {
 	*time.Duration
 }
 
-type Claims struct {
-	// Values may be json path like strings, or any other JSON primitive.
+type ClaimTemplates struct {
+	// Values may be json path like strings, or any other JSON primitive. Each entry will be used to come up with a
+	// claim about the credentialSubject in the credential that will be issued.
 	Data map[string]any
 }
 
-type Credential struct {
-	ID        string         `json:"id"`
-	Schema    string         `json:"schema"`
-	Data      CredentialData `json:"data"`
-	Expiry    TimeLike       `json:"expiry"`
-	Revocable bool           `json:"revocable"`
+type CredentialTemplate struct {
+	// ID corresponding to an OutputDescriptor.ID from the manifest.
+	ID string `json:"id"`
+
+	// ID of the CredentialSchema to be used for the issued credential.
+	Schema string `json:"schema"`
+
+	// Date that will be used to determine credential claims.
+	Data CredentialTemplateData `json:"data"`
+
+	// Parameter to determine the expiry of the credential.
+	Expiry TimeLike `json:"expiry"`
+
+	// Whether the credentials created should be revocable.
+	Revocable bool `json:"revocable"`
 }
 
 type IssuanceTemplate struct {
-	CredentialManifest string       `json:"credentialManifest"`
-	Issuer             string       `json:"issuer"`
-	Credentials        []Credential `json:"credentials"`
+	// ID of the credential manifest that this template corresponds to.
+	CredentialManifest string `json:"credentialManifest"`
+
+	// ID of the issuer that will be issuing the credentials.
+	Issuer string `json:"issuer"`
+
+	// Info required to create a credential from a credential application.
+	Credentials []CredentialTemplate `json:"credentials"`
 }
 
 type GetIssuanceTemplateResponse struct {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tbd54566975/ssi-service/pkg/service/credential"
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
+	"github.com/tbd54566975/ssi-service/pkg/service/issuing"
 	"github.com/tbd54566975/ssi-service/pkg/service/keystore"
 	"github.com/tbd54566975/ssi-service/pkg/service/manifest"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
@@ -43,6 +44,9 @@ func validateServiceConfig(config config.ServicesConfig) error {
 	}
 	if config.DIDConfig.IsEmpty() {
 		return fmt.Errorf("%s no config provided", framework.DID)
+	}
+	if config.IssuingServiceConfig.IsEmpty() {
+		return fmt.Errorf("%s no config provided", framework.Issuing)
 	}
 	if config.SchemaConfig.IsEmpty() {
 		return fmt.Errorf("%s no config provided", framework.Schema)
@@ -87,6 +91,11 @@ func instantiateServices(config config.ServicesConfig) ([]framework.Service, err
 		return nil, util.LoggingErrorMsg(err, "could not instantiate the schema service")
 	}
 
+	issuingService, err := issuing.NewIssuingService(config.IssuingServiceConfig, storageProvider)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not instantiate the issuing service")
+	}
+
 	credentialService, err := credential.NewCredentialService(config.CredentialConfig, storageProvider, keyStoreService, didResolver, schemaService)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not instantiate the credential service")
@@ -107,5 +116,5 @@ func instantiateServices(config config.ServicesConfig) ([]framework.Service, err
 		return nil, util.LoggingErrorMsg(err, "could not instantiate the operation service")
 	}
 
-	return []framework.Service{keyStoreService, didService, schemaService, credentialService, manifestService, presentationService, operationService}, nil
+	return []framework.Service{keyStoreService, didService, schemaService, issuingService, credentialService, manifestService, presentationService, operationService}, nil
 }


### PR DESCRIPTION
# Overview
This PR adds the scaffolding and service APIs needed for issuance templates.

# Description
What's included in this PR.
* Router layer for Create/Read/Delete/List Issuance Templates.
* Service layer for the same operations. 
* Service layer models that describe the request/response objects

# How Has This Been Tested?
Existing tests pass. Unit tests shall be added when the implementation is done.

# Checklist

Before submitting this PR, please make sure:

- [ ] I have read the CONTRIBUTING document.
- [ ] My code is consistent with the rest of the project 
- [ ] I have tagged the relevant reviewers and/or interested parties
- [ ] I have updated the READMEs and other documentation of affected packages

## References
SIP5 - see issuance template section.
