### PR TITLE
fixing namespace seeding issue

### DIFF
--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -220,7 +220,7 @@ func (s Service) CreateCredential(request CreateCredentialRequest) (*CreateCrede
 func getStatusListCredential(s Service, issuerID string, schemaID string) (*credential.VerifiableCredential, error) {
 	storedStatusListCreds, err := s.storage.GetStatusListCredentialsByIssuerAndSchema(issuerID, schemaID)
 	if err != nil {
-		return nil, util.LoggingNewErrorf("problem with getting status list credential for issuer: %s schema: %s", issuerID, schemaID)
+		logrus.Warnf("problem with getting status list credential for issuer: %s schema: %s. Continuing because this could be first time accessing this pair...", issuerID, schemaID)
 	}
 
 	// This should never happen, there should always be only 1 status list credential per <issuer,schema> pair

--- a/pkg/service/credential/storage.go
+++ b/pkg/service/credential/storage.go
@@ -78,25 +78,6 @@ func NewCredentialStorage(db storage.ServiceStorage) (*Storage, error) {
 		return nil, errors.New("bolt db reference is nil")
 	}
 
-	// TODO: (Neal) there is a current bug with our Bolt implementation where if we do a GET without anything in the db it will throw an error
-	// Doing initial writes and then deleting will "warm up" our database and when we do a GET after that it will not crash and return empty list
-	// https://github.com/TBD54566975/ssi-service/issues/176
-	if err := db.Write(credentialNamespace, fakeKey, nil); err != nil {
-		return nil, util.LoggingErrorMsg(err, "problem writing status initial write to db")
-
-	}
-	if err := db.Delete(credentialNamespace, fakeKey); err != nil {
-		return nil, util.LoggingErrorMsg(err, "problem with initial delete to db")
-	}
-
-	if err := db.Write(statusListCredentialNamespace, fakeKey, nil); err != nil {
-		return nil, util.LoggingErrorMsg(err, "problem writing status initial write to db")
-	}
-
-	if err := db.Delete(statusListCredentialNamespace, fakeKey); err != nil {
-		return nil, util.LoggingErrorMsg(err, "problem with initial delete to db")
-	}
-
 	randUniqueList := randomUniqueNum(bitStringLength)
 	uniqueNumBytes, err := json.Marshal(randUniqueList)
 	if err != nil {


### PR DESCRIPTION
Currently we do an empty write to the credential bolt db to get around a bug where if you do a read before anything is written it will throw an error

it's because the namespace bolt is using is created on first write. we should open up another issue to address it.
solutions:

https://github.com/TBD54566975/ssi-service/issues/176

I have handled this error by logic in the code.

If we think a better solution would be to NOT return an error if the bucket / namespace does not exist I am happy to implement that fix instead of this.