### PR TITLE
Added manual overrides for credential issuance upon application review.

### DIFF
--- a/integration/steelthread_integration_test.go
+++ b/integration/steelthread_integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"testing"
 
+	"github.com/TBD54566975/ssi-sdk/credential/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
 )
@@ -177,6 +178,10 @@ func TestSubmitAndReviewApplicationIntegration(t *testing.T) {
 	vc, err := getJSONElement(reviewApplicationOutput, "$.verifiableCredentials[0]")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vc)
+	typedVC, err := util.CredentialsFromInterface(vc)
+	assert.NoError(t, err)
+	assert.Equal(t, "Mister", typedVC.CredentialSubject["givenName"])
+	assert.Equal(t, "Tee", typedVC.CredentialSubject["familyName"])
 
 	operationOutput, err := get(endpoint + version + "operations/" + opID)
 	assert.NoError(t, err)

--- a/integration/testdata/review-application-input.json
+++ b/integration/testdata/review-application-input.json
@@ -1,4 +1,14 @@
 {
   "approved": {{.Approved}},
-  "reason": "{{.Reason}}"
+  "reason": "{{.Reason}}",
+  "credential_overrides": {
+    "kyc_credential": {
+      "data": {
+        "familyName": "Tee",
+        "givenName": "Mister"
+      },
+      "expiry": null,
+      "revocable": true
+    }
+  }
 }

--- a/pkg/server/router/manifest.go
+++ b/pkg/server/router/manifest.go
@@ -517,13 +517,18 @@ func (mr ManifestRouter) DeleteResponse(ctx context.Context, w http.ResponseWrit
 type ReviewApplicationRequest struct {
 	Approved bool   `json:"approved"`
 	Reason   string `json:"reason"`
+
+	// Overrides to apply to the credentials that will be created. Keys are the ID that corresponds to an
+	// OutputDescriptor.ID from the manifest.
+	CredentialOverrides map[string]model.CredentialOverride `json:"credential_overrides,omitempty"`
 }
 
 func (r ReviewApplicationRequest) toServiceRequest(id string) model.ReviewApplicationRequest {
 	return model.ReviewApplicationRequest{
-		ID:       id,
-		Approved: r.Approved,
-		Reason:   r.Reason,
+		ID:                  id,
+		Approved:            r.Approved,
+		Reason:              r.Reason,
+		CredentialOverrides: r.CredentialOverrides,
 	}
 }
 

--- a/pkg/service/manifest/model/model.go
+++ b/pkg/service/manifest/model/model.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	manifestsdk "github.com/TBD54566975/ssi-sdk/credential/manifest"
 	cred "github.com/tbd54566975/ssi-service/internal/credential"
@@ -93,6 +95,8 @@ type ReviewApplicationRequest struct {
 	ID       string `json:"id" validate:"required"`
 	Approved bool   `json:"approved"`
 	Reason   string `json:"reason"`
+
+	CredentialOverrides map[string]CredentialOverride `json:"credential_overrides,omitempty"`
 }
 
 // Response
@@ -120,4 +124,15 @@ func ServiceModel(storedResponse *storage.StoredResponse) SubmitApplicationRespo
 		Credentials: cred.ContainersToInterface(storedResponse.Credentials),
 		ResponseJWT: storedResponse.ResponseJWT,
 	}
+}
+
+type CredentialOverride struct {
+	// Data that will be used to determine credential claims.
+	Data map[string]any `json:"data"`
+
+	// Parameter to determine the expiry of the credential.
+	Expiry *time.Time `json:"expiry"`
+
+	// Whether the credentials created should be revocable.
+	Revocable bool `json:"revocable"`
 }

--- a/pkg/service/manifest/service.go
+++ b/pkg/service/manifest/service.go
@@ -374,17 +374,7 @@ func (s Service) maybeIssueAutomatically(
 		logrus.Warnf("found multiple issuance templates, using first entry only")
 	}
 
-	credResp, creds, err := s.buildCredentialResponse(
-		ctx,
-		applicantDID,
-		manifestID,
-		gotManifest.Manifest,
-		true,
-		"automatic creation via issuance template",
-		&issuanceTemplate,
-		request.Application,
-		request.ApplicationJSON,
-	)
+	credResp, creds, err := s.buildCredentialResponse(ctx, applicantDID, manifestID, gotManifest.Manifest, true, "automatic creation via issuance template", &issuanceTemplate, request.Application, request.ApplicationJSON, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -458,6 +448,7 @@ func (s Service) ReviewApplication(ctx context.Context, request model.ReviewAppl
 		nil,
 		application.Application,
 		nil,
+		request.CredentialOverrides,
 	)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not build credential response")


### PR DESCRIPTION
# Overview
When a review happens, the issuer admin might want to override some values that will be put in the credentials that will be produced.

# Description
This PR changes. Noteworthy: using a map instead of a list for the overrides. This is because the order of the overrides doesn't matter.

# How Has This Been Tested?
Added overrides for a credential in existing tests. Additionally modified the e2e tests. 

## References
Still part of SIP5