### PR TITLE
push to main_swagger

### DIFF
--- a/.github/workflows/swagger-doc.yml
+++ b/.github/workflows/swagger-doc.yml
@@ -36,7 +36,7 @@ jobs:
           git checkout -B main_swagger
           git add .; \
           git commit -m "gen OpenAPI Spec by github-actions"; \
-          git push
+          git push --set-upstream origin main_swagger
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this thing will be the death of me. 

Not easy to debug as only on merge to main

`git push --set-upstream origin main_swagger` is needed