### PR TITLE
Updated the Submission to contain the verifiablePresentation.

### DIFF
--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -244,8 +244,7 @@ func TestOperationsAPI(t *testing.T) {
 			var resp router.Operation
 			assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 			assert.True(t, resp.Done)
-			assert.Contains(t, resp.Result.Response, "definition_id")
-			assert.Contains(t, resp.Result.Response, "descriptor_map")
+			assert.Contains(t, resp.Result.Response, "verifiablePresentation")
 			assert.Equal(t, "cancelled", resp.Result.Response.(map[string]any)["status"])
 		})
 

--- a/pkg/service/presentation/service.go
+++ b/pkg/service/presentation/service.go
@@ -179,8 +179,8 @@ func (s Service) CreateSubmission(ctx context.Context, request model.CreateSubmi
 	}
 
 	storedSubmission := presentationstorage.StoredSubmission{
-		Status:     submission.StatusPending,
-		Submission: request.Submission,
+		Status:                 submission.StatusPending,
+		VerifiablePresentation: request.Presentation,
 	}
 
 	// TODO(andres): IO requests should be done in parallel, once we have context wired up.
@@ -188,7 +188,11 @@ func (s Service) CreateSubmission(ctx context.Context, request model.CreateSubmi
 		return nil, errors.Wrap(err, "could not store presentation")
 	}
 
-	opID := submission.IDFromSubmissionID(storedSubmission.Submission.ID)
+	sub, ok := storedSubmission.VerifiablePresentation.PresentationSubmission.(exchange.PresentationSubmission)
+	if !ok {
+		return nil, errors.New("interface is not exchange.PresentationSubmission")
+	}
+	opID := submission.IDFromSubmissionID(sub.ID)
 	storedOp := opstorage.StoredOperation{
 		ID:   opID,
 		Done: false,

--- a/pkg/service/presentation/storage.go
+++ b/pkg/service/presentation/storage.go
@@ -140,7 +140,11 @@ func (ps *Storage) DeletePresentation(ctx context.Context, id string) error {
 }
 
 func (ps *Storage) StoreSubmission(ctx context.Context, s prestorage.StoredSubmission) error {
-	id := s.Submission.ID
+	sub, ok := s.VerifiablePresentation.PresentationSubmission.(exchange.PresentationSubmission)
+	if !ok {
+		return util.LoggingNewError("asserting that field is of type exchange.PresentationSubmission")
+	}
+	id := sub.ID
 	if id == "" {
 		err := errors.New("could not store submission definition without an ID")
 		logrus.WithError(err).Error()

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/pkg/errors"
 	opstorage "github.com/tbd54566975/ssi-service/pkg/service/operation/storage"
@@ -26,9 +27,9 @@ type DefinitionStorage interface {
 }
 
 type StoredSubmission struct {
-	Status     submission.Status               `json:"status"`
-	Submission exchange.PresentationSubmission `json:"submission"`
-	Reason     string                          `json:"reason"`
+	Status                 submission.Status                 `json:"status"`
+	Reason                 string                            `json:"reason"`
+	VerifiablePresentation credential.VerifiablePresentation `json:"vp"`
 }
 
 func (s StoredSubmission) FilterVariablesMap() map[string]any {


### PR DESCRIPTION
# Overview
Previously: a Submission object (which is returned with `GetSubmission`) contained metadata only.
Now: it contains the `VerifiablePresentation` object that was sent.

# Description
This is so API clients can retrieve what the information sent was. An follow up may be to include the JWT that was sent, instead of the actual decoded payload.

# How Has This Been Tested?
Unit


