### PR TITLE
Enable cors as an option. Docker default to allowing all.

### DIFF
--- a/config/compose.toml
+++ b/config/compose.toml
@@ -20,6 +20,7 @@ log_location = "logs"
 log_level = "info"
 
 enable_schema_caching = true
+enable_allow_all_cors = true
 
 # Storage Configuration
 [services]

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type ServerConfig struct {
 	LogLocation         string        `toml:"log_location" conf:"default:log"`
 	LogLevel            string        `toml:"log_level" conf:"default:debug"`
 	EnableSchemaCaching bool          `toml:"enable_schema_caching" conf:"default:true"`
+	EnableAllowAllCORS  bool          `toml:"enable_allow_all_cors" conf:"default:false"`
 }
 
 type IssuingServiceConfig struct {

--- a/config/config.toml
+++ b/config/config.toml
@@ -18,6 +18,7 @@ log_location = "logs"
 log_level = "debug"
 
 enable_schema_caching = true
+enable_allow_all_cors = true
 
 # Storage Configuration
 [services]

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/pkg/errors v0.9.1
+	github.com/rs/cors v1.8.3
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	go.einride.tech/aip v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
+github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/santhosh-tekuri/jsonschema/v5 v5.1.1 h1:lEOLY2vyGIqKWUI9nzsOJRV3mb3WC9dXYORsLEUcoeY=
 github.com/santhosh-tekuri/jsonschema/v5 v5.1.1/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/integration/common.go
+++ b/integration/common.go
@@ -353,16 +353,9 @@ func getJSONElement(jsonString string, jsonPath string) (string, error) {
 func get(url string) (string, error) {
 	logrus.Println(fmt.Sprintf("\nPerforming GET request to:  %s\n", url))
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := http.Get(url) // #nosec: testing only.
 	if err != nil {
-		return "", errors.Wrap(err, "building http req")
-	}
-
-	req.Header.Set("Origin", "http://foo.com")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", errors.Wrap(err, "client http client")
+		return "", errors.Wrapf(err, "getting url: %s", url)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -387,7 +380,6 @@ func put(url string, json string) (string, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Origin", "http://foo.com")
 	client.Timeout = 90 * time.Second
 	resp, err := client.Do(req)
 	if err != nil {

--- a/integration/common.go
+++ b/integration/common.go
@@ -353,9 +353,16 @@ func getJSONElement(jsonString string, jsonPath string) (string, error) {
 func get(url string) (string, error) {
 	logrus.Println(fmt.Sprintf("\nPerforming GET request to:  %s\n", url))
 
-	resp, err := http.Get(url) // #nosec: testing only.
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return "", errors.Wrapf(err, "getting url: %s", url)
+		return "", errors.Wrap(err, "building http req")
+	}
+
+	req.Header.Set("Origin", "http://foo.com")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, "client http client")
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -380,6 +387,7 @@ func put(url string, json string) (string, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://foo.com")
 	client.Timeout = 90 * time.Second
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/server/middleware/cors.go
+++ b/pkg/server/middleware/cors.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/tbd54566975/ssi-service/pkg/server/framework"
+)
+
+func Cors() framework.Middleware {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+		Debug:            true,
+	})
+	return func(handler framework.Handler) framework.Handler {
+		return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			c.HandlerFunc(w, r)
+			return handler(ctx, w, r)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,6 +56,9 @@ func NewSSIServer(shutdown chan os.Signal, config config.SSIServiceConfig) (*SSI
 		middleware.Metrics(),
 		middleware.Panics(),
 	}
+	if config.Server.EnableAllowAllCORS {
+		middlewares = append(middlewares, middleware.Cors())
+	}
 	httpServer := framework.NewHTTPServer(config.Server, shutdown, middlewares...)
 	ssi, err := service.InstantiateSSIService(config.Services)
 	if err != nil {


### PR DESCRIPTION
With this change, you can request resources from a browser after running `mage run`