### PR TITLE
Credential suspension

### DIFF
--- a/internal/credential/model.go
+++ b/internal/credential/model.go
@@ -20,6 +20,7 @@ type Container struct {
 	Credential    *credential.VerifiableCredential
 	CredentialJWT *keyaccess.JWT
 	Revoked       bool
+	Suspended     bool
 }
 
 func (c Container) JWTString() string {

--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -61,18 +61,23 @@ type CreateCredentialRequest struct {
 	// Whether this credential can be revoked. When true, the created VC will have the "credentialStatus"
 	// property set.
 	Revocable bool `json:"revocable"`
+
+	// Whether this credential can be suspended. When true, the created VC will have the "credentialStatus"
+	// property set.
+	Suspendable bool `json:"suspendable"`
 	// TODO(gabe) support more capabilities like signature type, format, status, and more.
 }
 
 func (c CreateCredentialRequest) ToServiceRequest() credential.CreateCredentialRequest {
 	return credential.CreateCredentialRequest{
-		Issuer:     c.Issuer,
-		Subject:    c.Subject,
-		Context:    c.Context,
-		JSONSchema: c.Schema,
-		Data:       c.Data,
-		Expiry:     c.Expiry,
-		Revocable:  c.Revocable,
+		Issuer:      c.Issuer,
+		Subject:     c.Subject,
+		Context:     c.Context,
+		JSONSchema:  c.Schema,
+		Data:        c.Data,
+		Expiry:      c.Expiry,
+		Revocable:   c.Revocable,
+		Suspendable: c.Suspendable,
 	}
 }
 
@@ -164,6 +169,8 @@ func (cr CredentialRouter) GetCredential(ctx context.Context, w http.ResponseWri
 type GetCredentialStatusResponse struct {
 	// Whether the credential has been revoked.
 	Revoked bool `json:"revoked"`
+	// Whether the credential has been suspended.
+	Suspended bool `json:"suspended"`
 }
 
 // GetCredentialStatus godoc
@@ -194,7 +201,8 @@ func (cr CredentialRouter) GetCredentialStatus(ctx context.Context, w http.Respo
 	}
 
 	resp := GetCredentialStatusResponse{
-		Revoked: getCredentialStatusResponse.Revoked,
+		Revoked:   getCredentialStatusResponse.Revoked,
+		Suspended: getCredentialStatusResponse.Suspended,
 	}
 
 	return framework.Respond(ctx, w, resp, http.StatusOK)
@@ -248,19 +256,22 @@ func (cr CredentialRouter) GetCredentialStatusList(ctx context.Context, w http.R
 type UpdateCredentialStatusRequest struct {
 	// The new revoked status of this credential. The status will be saved in the encodedList of the StatusList2021
 	// credential associated with this VC.
-	Revoked bool `json:"revoked" validate:"required"`
+	Revoked   bool `json:"revoked,omitempty"`
+	Suspended bool `json:"suspended,omitempty"`
 }
 
 func (c UpdateCredentialStatusRequest) ToServiceRequest(id string) credential.UpdateCredentialStatusRequest {
 	return credential.UpdateCredentialStatusRequest{
-		ID:      id,
-		Revoked: c.Revoked,
+		ID:        id,
+		Revoked:   c.Revoked,
+		Suspended: c.Suspended,
 	}
 }
 
 type UpdateCredentialStatusResponse struct {
 	// The updated status of this credential.
-	Revoked bool `json:"revoked"`
+	Revoked   bool `json:"revoked"`
+	Suspended bool `json:"suspended"`
 }
 
 // UpdateCredentialStatus godoc
@@ -307,7 +318,8 @@ func (cr CredentialRouter) UpdateCredentialStatus(ctx context.Context, w http.Re
 	}
 
 	resp := UpdateCredentialStatusResponse{
-		Revoked: gotCredential.Revoked,
+		Revoked:   gotCredential.Revoked,
+		Suspended: gotCredential.Suspended,
 	}
 
 	return framework.Respond(ctx, w, resp, http.StatusOK)

--- a/pkg/server/router/credential_test.go
+++ b/pkg/server/router/credential_test.go
@@ -602,7 +602,7 @@ func TestCredentialRouter(t *testing.T) {
 		assert.Equal(tt, statusListIndexes, statusListIndexesAfterRestart)
 	})
 
-	t.Run("Test Create Suspendable Credential", func(tt *testing.T) {
+	t.Run("Create Suspendable Credential", func(tt *testing.T) {
 		issuer, schema, credService := createCredServicePrereqs(tt)
 		subject := "did:test:345"
 
@@ -656,7 +656,7 @@ func TestCredentialRouter(t *testing.T) {
 		assert.False(tt, valid)
 	})
 
-	t.Run("Test Update Suspendable Credential", func(tt *testing.T) {
+	t.Run("Update Suspendable Credential To Suspended", func(tt *testing.T) {
 		issuer, schema, credService := createCredServicePrereqs(tt)
 		subject := "did:test:345"
 

--- a/pkg/server/router/credential_test.go
+++ b/pkg/server/router/credential_test.go
@@ -601,4 +601,244 @@ func TestCredentialRouter(t *testing.T) {
 
 		assert.Equal(tt, statusListIndexes, statusListIndexesAfterRestart)
 	})
+
+	t.Run("Test Create Suspendable Credential", func(tt *testing.T) {
+		issuer, schema, credService := createCredServicePrereqs(tt)
+		subject := "did:test:345"
+
+		createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
+			Issuer:     issuer,
+			Subject:    subject,
+			JSONSchema: schema,
+			Data: map[string]any{
+				"email": "Satoshi@Nakamoto.btc",
+			},
+			Expiry:      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			Suspendable: true,
+		})
+
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, createdCred)
+		assert.NotEmpty(tt, createdCred.CredentialJWT)
+
+		statusBytes, err := json.Marshal(createdCred.Credential.CredentialStatus)
+		assert.NoError(tt, err)
+
+		var statusEntry status.StatusList2021Entry
+		err = json.Unmarshal(statusBytes, &statusEntry)
+		assert.NoError(tt, err)
+
+		assert.Contains(tt, statusEntry.ID, fmt.Sprintf("http://localhost:1234/v1/credentials/%s/status", createdCred.ID))
+		assert.Contains(tt, statusEntry.StatusListCredential, "http://localhost:1234/v1/credentials/status")
+		assert.NotEmpty(tt, statusEntry.StatusListIndex)
+
+		credStatus, err := credService.GetCredentialStatus(context.Background(), credential.GetCredentialStatusRequest{ID: createdCred.ID})
+		assert.NoError(tt, err)
+		assert.Equal(tt, credStatus.Revoked, false)
+		assert.Equal(tt, credStatus.Suspended, false)
+
+		credStatusListStr := statusEntry.StatusListCredential
+
+		credStatusListID := strings.Split(credStatusListStr, "/")[len(strings.Split(credStatusListStr, "/"))-1]
+		credStatusList, err := credService.GetCredentialStatusList(context.Background(), credential.GetCredentialStatusListRequest{ID: credStatusListID})
+		assert.NoError(tt, err)
+		assert.Equal(tt, credStatusList.Credential.ID, statusEntry.StatusListCredential)
+
+		credentialSubject := credStatusList.Container.Credential.CredentialSubject
+		assert.NotEmpty(tt, credentialSubject)
+
+		encodedList := credentialSubject["encodedList"]
+		assert.NotEmpty(tt, encodedList)
+
+		// Validate the StatusListIndex in not flipped in the credStatusList
+		valid, err := status.ValidateCredentialInStatusList(*createdCred.Credential, *credStatusList.Credential)
+		assert.NoError(tt, err)
+		assert.False(tt, valid)
+	})
+
+	t.Run("Test Update Suspendable Credential", func(tt *testing.T) {
+		issuer, schema, credService := createCredServicePrereqs(tt)
+		subject := "did:test:345"
+
+		createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
+			Issuer:     issuer,
+			Subject:    subject,
+			JSONSchema: schema,
+			Data: map[string]any{
+				"email": "Satoshi@Nakamoto.btc",
+			},
+			Expiry:      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			Suspendable: true,
+		})
+
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, createdCred)
+		assert.NotEmpty(tt, createdCred.CredentialJWT)
+
+		statusBytes, err := json.Marshal(createdCred.Credential.CredentialStatus)
+		assert.NoError(tt, err)
+
+		var statusEntry status.StatusList2021Entry
+		err = json.Unmarshal(statusBytes, &statusEntry)
+		assert.NoError(tt, err)
+
+		assert.Contains(tt, statusEntry.ID, fmt.Sprintf("http://localhost:1234/v1/credentials/%s/status", createdCred.ID))
+		assert.Contains(tt, statusEntry.StatusListCredential, "http://localhost:1234/v1/credentials/status")
+		assert.NotEmpty(tt, statusEntry.StatusListIndex)
+
+		credStatus, err := credService.GetCredentialStatus(context.Background(), credential.GetCredentialStatusRequest{ID: createdCred.ID})
+		assert.NoError(tt, err)
+		assert.Equal(tt, credStatus.Revoked, false)
+		assert.Equal(tt, credStatus.Suspended, false)
+
+		credStatusListStr := statusEntry.StatusListCredential
+
+		credStatusListID := strings.Split(credStatusListStr, "/")[len(strings.Split(credStatusListStr, "/"))-1]
+		credStatusList, err := credService.GetCredentialStatusList(context.Background(), credential.GetCredentialStatusListRequest{ID: credStatusListID})
+		assert.NoError(tt, err)
+		assert.Equal(tt, credStatusList.Credential.ID, statusEntry.StatusListCredential)
+
+		credentialSubject := credStatusList.Container.Credential.CredentialSubject
+		assert.NotEmpty(tt, credentialSubject)
+
+		encodedList := credentialSubject["encodedList"]
+		assert.NotEmpty(tt, encodedList)
+
+		// Validate the StatusListIndex in not flipped in the credStatusList
+		valid, err := status.ValidateCredentialInStatusList(*createdCred.Credential, *credStatusList.Credential)
+		assert.NoError(tt, err)
+		assert.False(tt, valid)
+
+		updatedStatus, err := credService.UpdateCredentialStatus(context.Background(), credential.UpdateCredentialStatusRequest{ID: createdCred.ID, Suspended: true})
+		assert.NoError(tt, err)
+		assert.Equal(tt, updatedStatus.Suspended, true)
+		assert.Equal(tt, updatedStatus.Revoked, false)
+
+		credStatusListAfterRevoke, err := credService.GetCredentialStatusList(context.Background(), credential.GetCredentialStatusListRequest{ID: credStatusListID})
+		assert.NoError(tt, err)
+		assert.Equal(tt, credStatusListAfterRevoke.Credential.ID, statusEntry.StatusListCredential)
+
+		// Validate the StatusListIndex in flipped in the credStatusList
+		valid, err = status.ValidateCredentialInStatusList(*createdCred.Credential, *credStatusListAfterRevoke.Credential)
+		assert.NoError(tt, err)
+		assert.True(tt, valid)
+
+		credentialSubjectAfterRevoke := credStatusListAfterRevoke.Container.Credential.CredentialSubject
+		assert.NotEmpty(tt, credentialSubjectAfterRevoke)
+
+		encodedListAfterSuspended := credentialSubjectAfterRevoke["encodedList"]
+		assert.NotEmpty(tt, encodedListAfterSuspended)
+
+		assert.NotEqualValues(tt, encodedListAfterSuspended, encodedList)
+	})
+
+	t.Run("Create Suspendable and Revocable Credential Should Be Error", func(tt *testing.T) {
+		issuer, schema, credService := createCredServicePrereqs(tt)
+		subject := "did:test:345"
+
+		createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
+			Issuer:     issuer,
+			Subject:    subject,
+			JSONSchema: schema,
+			Data: map[string]any{
+				"email": "Satoshi@Nakamoto.btc",
+			},
+			Expiry:      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			Revocable:   true,
+			Suspendable: true,
+		})
+
+		assert.Error(tt, err)
+		assert.ErrorContains(tt, err, "credential cannot be revocable and suspendable")
+		assert.Empty(tt, createdCred)
+	})
+
+	t.Run("Update Suspendable and Revocable Credential Should Be Error", func(tt *testing.T) {
+		issuer, schema, credService := createCredServicePrereqs(tt)
+		subject := "did:test:345"
+
+		createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
+			Issuer:     issuer,
+			Subject:    subject,
+			JSONSchema: schema,
+			Data: map[string]any{
+				"email": "Satoshi@Nakamoto.btc",
+			},
+			Expiry:      time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			Suspendable: true,
+		})
+
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, createdCred)
+
+		updatedStatus, err := credService.UpdateCredentialStatus(context.Background(), credential.UpdateCredentialStatusRequest{ID: createdCred.ID, Revoked: true, Suspended: true})
+		assert.Nil(tt, updatedStatus)
+		assert.Error(tt, err)
+		assert.ErrorContains(tt, err, "cannot update both suspended and revoked status")
+	})
+
+	t.Run("Update Suspended On Revoked Credential Should Be Error", func(tt *testing.T) {
+		issuer, schema, credService := createCredServicePrereqs(tt)
+		subject := "did:test:345"
+
+		createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
+			Issuer:     issuer,
+			Subject:    subject,
+			JSONSchema: schema,
+			Data: map[string]any{
+				"email": "Satoshi@Nakamoto.btc",
+			},
+			Expiry:    time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			Revocable: true,
+		})
+
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, createdCred)
+
+		updatedStatus, err := credService.UpdateCredentialStatus(context.Background(), credential.UpdateCredentialStatusRequest{ID: createdCred.ID, Suspended: true})
+		assert.Nil(tt, updatedStatus)
+		assert.Error(tt, err)
+		assert.ErrorContains(tt, err, "has a different status purpose<revocation> value than the status credential<suspension>")
+	})
+
+}
+
+func createCredServicePrereqs(tt *testing.T) (string, string, credential.Service) {
+	bolt := setupTestDB(tt)
+	assert.NotNil(tt, bolt)
+
+	serviceConfig := config.CredentialServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "credential", ServiceEndpoint: "http://localhost:1234"}}
+	keyStoreService := testKeyStoreService(tt, bolt)
+	didService := testDIDService(tt, bolt, keyStoreService)
+	schemaService := testSchemaService(tt, bolt, keyStoreService, didService)
+	credService, err := credential.NewCredentialService(serviceConfig, bolt, keyStoreService, didService.GetResolver(), schemaService)
+	assert.NoError(tt, err)
+	assert.NotEmpty(tt, credService)
+
+	// check type and status
+	assert.Equal(tt, framework.Credential, credService.Type())
+	assert.Equal(tt, framework.StatusReady, credService.Status().Status)
+
+	// create a did
+	issuerDID, err := didService.CreateDIDByMethod(context.Background(), did.CreateDIDRequest{Method: didsdk.KeyMethod, KeyType: crypto.Ed25519})
+	assert.NoError(tt, err)
+	assert.NotEmpty(tt, issuerDID)
+
+	// create a schema
+	emailSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"email": map[string]any{
+				"type": "string",
+			},
+		},
+		"required":             []any{"email"},
+		"additionalProperties": false,
+	}
+
+	createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Author: "me", Name: "simple schema", Schema: emailSchema})
+	assert.NoError(tt, err)
+	assert.NotEmpty(tt, createdSchema)
+
+	return issuerDID.DID.ID, createdSchema.ID, *credService
 }

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -18,7 +18,7 @@ type CreateCredentialRequest struct {
 	Data        map[string]any `json:"data,omitempty"`
 	Expiry      string         `json:"expiry,omitempty"`
 	Revocable   bool           `json:"revocable,omitempty"`
-	Suspendable bool           `json:"revocable,omitempty"`
+	Suspendable bool           `json:"suspendable,omitempty"`
 	// TODO(gabe) support more capabilities like signature type, format, status, and more.
 }
 

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -14,10 +14,11 @@ type CreateCredentialRequest struct {
 	// A context is optional. If not present, we'll apply default, required context values.
 	Context string `json:"context,omitempty"`
 	// A schema is optional. If present, we'll attempt to look it up and validate the data against it.
-	JSONSchema string         `json:"jsonSchema,omitempty"`
-	Data       map[string]any `json:"data,omitempty"`
-	Expiry     string         `json:"expiry,omitempty"`
-	Revocable  bool           `json:"revocable,omitempty"`
+	JSONSchema  string         `json:"jsonSchema,omitempty"`
+	Data        map[string]any `json:"data,omitempty"`
+	Expiry      string         `json:"expiry,omitempty"`
+	Revocable   bool           `json:"revocable,omitempty"`
+	Suspendable bool           `json:"revocable,omitempty"`
 	// TODO(gabe) support more capabilities like signature type, format, status, and more.
 }
 
@@ -60,16 +61,19 @@ type GetCredentialStatusRequest struct {
 }
 
 type GetCredentialStatusResponse struct {
-	Revoked bool `json:"revoked" validate:"required"`
+	Revoked   bool `json:"revoked" validate:"required"`
+	Suspended bool `json:"suspended" validate:"required"`
 }
 
 type UpdateCredentialStatusRequest struct {
-	ID      string `json:"id" validate:"required"`
-	Revoked bool   `json:"revoked" validate:"required"`
+	ID        string `json:"id" validate:"required"`
+	Revoked   bool   `json:"revoked" validate:"required"`
+	Suspended bool   `json:"suspended" validate:"required"`
 }
 
 type UpdateCredentialStatusResponse struct {
-	Revoked bool `json:"revoked" validate:"required"`
+	Revoked   bool `json:"revoked" validate:"required"`
+	Suspended bool `json:"suspended" validate:"required"`
 }
 
 type GetCredentialStatusListRequest struct {

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -83,3 +83,10 @@ type GetCredentialStatusListRequest struct {
 type GetCredentialStatusListResponse struct {
 	credential.Container `json:"credential,omitempty"`
 }
+
+func (csr CreateCredentialRequest) isStatusValid() bool {
+	if csr.Revocable && csr.Suspendable {
+		return false
+	}
+	return true
+}

--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -116,6 +116,10 @@ func (s Service) createCredentialFunc(request CreateCredentialRequest) storage.B
 func (s Service) createCredentialBusinessLogic(ctx context.Context, request CreateCredentialRequest, tx storage.Tx) (*CreateCredentialResponse, error) {
 	logrus.Debugf("creating credential: %+v", request)
 
+	if request.Revocable && request.Suspendable {
+		return nil, util.LoggingNewError("credential cannot be revocable and suspendable")
+	}
+
 	builder := credential.NewVerifiableCredentialBuilder()
 
 	if err := builder.SetIssuer(request.Issuer); err != nil {
@@ -173,12 +177,18 @@ func (s Service) createCredentialBusinessLogic(ctx context.Context, request Crea
 		return nil, util.LoggingErrorMsg(err, errMsg)
 	}
 
-	if request.Revocable {
+	if request.Revocable || request.Suspendable {
 		credID := builder.ID
 		issuerID := request.Issuer
 		schemaID := request.JSONSchema
 
-		statusListCredential, err := getOrCreateStatusListCredential(ctx, s, issuerID, schemaID, tx)
+		statusPurpose := statussdk.StatusRevocation
+
+		if request.Suspendable {
+			statusPurpose = statussdk.StatusSuspension
+		}
+
+		statusListCredential, err := getOrCreateStatusListCredential(ctx, s, statusPurpose, issuerID, schemaID, tx)
 		if err != nil {
 			return nil, util.LoggingErrorMsgf(err, "problem with getting status list credential")
 		}
@@ -195,7 +205,7 @@ func (s Service) createCredentialBusinessLogic(ctx context.Context, request Crea
 		status := statussdk.StatusList2021Entry{
 			ID:                   fmt.Sprintf(`%s/v1/credentials/%s/status`, s.config.ServiceEndpoint, credID),
 			Type:                 statussdk.StatusList2021EntryType,
-			StatusPurpose:        statussdk.StatusRevocation,
+			StatusPurpose:        statusPurpose,
 			StatusListIndex:      strconv.Itoa(statusListIndex),
 			StatusListCredential: statusListCredential.ID,
 		}
@@ -228,6 +238,7 @@ func (s Service) createCredentialBusinessLogic(ctx context.Context, request Crea
 		Credential:    cred,
 		CredentialJWT: credJWT,
 		Revoked:       false,
+		Suspended:     false,
 	}
 
 	credentialStorageRequest := StoreCredentialRequest{
@@ -242,8 +253,8 @@ func (s Service) createCredentialBusinessLogic(ctx context.Context, request Crea
 	return &response, nil
 }
 
-func getOrCreateStatusListCredential(ctx context.Context, s Service, issuerID string, schemaID string, tx storage.Tx) (*credential.VerifiableCredential, error) {
-	storedStatusListCreds, err := s.storage.GetStatusListCredentialsByIssuerAndSchema(ctx, issuerID, schemaID)
+func getOrCreateStatusListCredential(ctx context.Context, s Service, statusPurpose statussdk.StatusPurpose, issuerID string, schemaID string, tx storage.Tx) (*credential.VerifiableCredential, error) {
+	storedStatusListCreds, err := s.storage.GetStatusListCredentialsByIssuerAndSchema(ctx, statusPurpose, issuerID, schemaID)
 	if err != nil {
 		return nil, util.LoggingNewErrorf("getting status list credential for issuer: %s schema: %s", issuerID, schemaID)
 	}
@@ -257,8 +268,9 @@ func getOrCreateStatusListCredential(ctx context.Context, s Service, issuerID st
 
 	// First time that this <issuer,schema> pair has a revocation or suspension credential issued
 	if len(storedStatusListCreds) == 0 {
-		statusListID := fmt.Sprintf("%s/v1/credentials/status/%s", s.config.ServiceEndpoint, uuid.New().String())
-		generatedStatusListCredential, err := statussdk.GenerateStatusList2021Credential(statusListID, issuerID, statussdk.StatusRevocation, []credential.VerifiableCredential{})
+		statusListUUID := uuid.New().String()
+		statusListID := fmt.Sprintf("%s/v1/credentials/status/%s", s.config.ServiceEndpoint, statusListUUID)
+		generatedStatusListCredential, err := statussdk.GenerateStatusList2021Credential(statusListID, issuerID, statusPurpose, []credential.VerifiableCredential{})
 		if err != nil {
 			return nil, util.LoggingErrorMsg(err, "could not generate status list")
 		}
@@ -288,7 +300,7 @@ func getOrCreateStatusListCredential(ctx context.Context, s Service, issuerID st
 			Container: statusListContainer,
 		}
 
-		if err := s.storage.StoreStatusListCredentialTx(ctx, statusListStorageRequest, tx); err != nil {
+		if err := s.storage.StoreStatusListCredentialTx(ctx, statusListStorageRequest, statusPurpose, tx); err != nil {
 			return nil, errors.Wrap(err, "storing status list credential")
 		}
 	} else {
@@ -516,6 +528,10 @@ func (s Service) updateCredentialStatusFunc(request UpdateCredentialStatusReques
 func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, request UpdateCredentialStatusRequest, tx storage.Tx) (*UpdateCredentialStatusResponse, error) {
 	logrus.Debugf("updating credential status: %s to Revoked: %v", request.ID, request.Revoked)
 
+	if request.Suspended && request.Revoked {
+		return nil, util.LoggingNewErrorf("cannot update both suspended and revoked status")
+	}
+
 	gotCred, err := s.storage.GetCredential(ctx, request.ID)
 	if err != nil {
 		return nil, util.LoggingErrorMsgf(err, "could not get credential: %s", request.ID)
@@ -525,8 +541,8 @@ func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, reques
 	}
 
 	// if the request is the same as what the current credential is there is no action
-	if gotCred.Revoked == request.Revoked {
-		response := UpdateCredentialStatusResponse{Revoked: gotCred.Revoked}
+	if gotCred.Revoked == request.Revoked && gotCred.Suspended == request.Suspended {
+		response := UpdateCredentialStatusResponse{Revoked: gotCred.Revoked, Suspended: gotCred.Suspended}
 		return &response, nil
 	}
 
@@ -535,7 +551,7 @@ func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, reques
 		return nil, util.LoggingErrorMsg(err, "updating credential")
 	}
 
-	response := UpdateCredentialStatusResponse{Revoked: container.Revoked}
+	response := UpdateCredentialStatusResponse{Revoked: container.Revoked, Suspended: container.Suspended}
 	return &response, nil
 }
 
@@ -546,6 +562,7 @@ func updateCredentialStatus(ctx context.Context, s Service, gotCred *StoredCrede
 		Credential:    gotCred.Credential,
 		CredentialJWT: gotCred.CredentialJWT,
 		Revoked:       request.Revoked,
+		Suspended:     request.Suspended,
 	}
 
 	storageRequest := StoreCredentialRequest{
@@ -567,14 +584,22 @@ func updateCredentialStatus(ctx context.Context, s Service, gotCred *StoredCrede
 		return nil, util.LoggingNewErrorf("problem with getting status list credential for issuer: %s schema: %s", gotCred.Issuer, gotCred.Schema)
 	}
 
-	var revokedStatusCreds []credential.VerifiableCredential
+	var revokedOrSuspendedStatusCreds []credential.VerifiableCredential
 	for _, cred := range creds {
-		if cred.Credential.CredentialStatus != nil && cred.Revoked {
-			revokedStatusCreds = append(revokedStatusCreds, *cred.Credential)
+		if request.Revoked && cred.Credential.CredentialStatus != nil && cred.Revoked {
+			revokedOrSuspendedStatusCreds = append(revokedOrSuspendedStatusCreds, *cred.Credential)
+		} else if request.Suspended && cred.Credential.CredentialStatus != nil && cred.Suspended {
+			revokedOrSuspendedStatusCreds = append(revokedOrSuspendedStatusCreds, *cred.Credential)
 		}
 	}
 
-	generatedStatusListCredential, err := statussdk.GenerateStatusList2021Credential(statusListCredentialID, gotCred.Issuer, statussdk.StatusRevocation, revokedStatusCreds)
+	statusPurpose := statussdk.StatusRevocation
+
+	if request.Suspended {
+		statusPurpose = statussdk.StatusSuspension
+	}
+
+	generatedStatusListCredential, err := statussdk.GenerateStatusList2021Credential(statusListCredentialID, gotCred.Issuer, statusPurpose, revokedOrSuspendedStatusCreds)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not generate status list")
 	}
@@ -597,7 +622,7 @@ func updateCredentialStatus(ctx context.Context, s Service, gotCred *StoredCrede
 		Container: statusListContainer,
 	}
 
-	if err = s.storage.StoreStatusListCredentialTx(ctx, storageRequest, tx); err != nil {
+	if err = s.storage.StoreStatusListCredentialTx(ctx, storageRequest, statusPurpose, tx); err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not store credential status list")
 	}
 

--- a/pkg/service/credential/storage.go
+++ b/pkg/service/credential/storage.go
@@ -227,7 +227,7 @@ func (cs *Storage) StoreCredential(ctx context.Context, request StoreCredentialR
 	return cs.storeCredential(ctx, request, credentialNamespace)
 }
 
-func (cs *Storage) StoreStatusListCredentialTx(ctx context.Context, request StoreCredentialRequest, statusPurpose statussdk.StatusPurpose, tx storage.Tx) error {
+func (cs *Storage) StoreStatusListCredentialTx(ctx context.Context, tx storage.Tx, request StoreCredentialRequest, statusPurpose statussdk.StatusPurpose) error {
 	if !request.IsValid() {
 		return util.LoggingNewError("store request request is not valid")
 	}
@@ -235,7 +235,7 @@ func (cs *Storage) StoreStatusListCredentialTx(ctx context.Context, request Stor
 	// transform the credential into its denormalized form for storage
 	storedCredential, err := buildStoredCredential(request)
 	if err != nil {
-		return errors.Wrap(err, "could not build stored credential")
+		return errors.Wrap(err, "building stored credential")
 	}
 
 	storedCredBytes, err := json.Marshal(storedCredential)
@@ -282,7 +282,8 @@ func (cs *Storage) storeCredential(ctx context.Context, request StoreCredentialR
 
 	wc, err := cs.getStoreCredentialWriteContext(request, namespace)
 	if err != nil {
-		return errors.Wrap(err, "could not get stored credential write context")
+		return errors.Wrap(err, "building stored credential")
+
 	}
 	// TODO(gabe) conflict checking?
 	return cs.db.Write(ctx, wc.namespace, wc.key, wc.value)
@@ -300,7 +301,7 @@ func (cs *Storage) getStoreCredentialWriteContext(request StoreCredentialRequest
 	// transform the credential into its denormalized form for storage
 	storedCredential, err := buildStoredCredential(request)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not build stored credential")
+		return nil, errors.Wrap(err, "building stored credential")
 	}
 
 	storedCredBytes, err := json.Marshal(storedCredential)

--- a/pkg/service/credential/storage.go
+++ b/pkg/service/credential/storage.go
@@ -138,7 +138,7 @@ func (cs *Storage) GetNextStatusListRandomIndex(ctx context.Context) (int, error
 
 	var uniqueNums []int
 	if err = json.Unmarshal(gotUniqueNumBytes, &uniqueNums); err != nil {
-		return -1, util.LoggingErrorMsgf(err, "could not unmarshal unique numbers")
+		return -1, util.LoggingErrorMsgf(err, "unmarshalling unique numbers")
 	}
 
 	gotCurrentListIndexBytes, err := cs.db.Read(ctx, statusListIndexNamespace, currentListIndexKey)
@@ -148,7 +148,7 @@ func (cs *Storage) GetNextStatusListRandomIndex(ctx context.Context) (int, error
 
 	var statusListIndex StatusListIndex
 	if err = json.Unmarshal(gotCurrentListIndexBytes, &statusListIndex); err != nil {
-		return -1, util.LoggingErrorMsgf(err, "could not unmarshal unique numbers")
+		return -1, util.LoggingErrorMsgf(err, "unmarshalling unique numbers")
 	}
 
 	return uniqueNums[statusListIndex.Index], nil
@@ -202,7 +202,7 @@ func (cs *Storage) GetIncrementStatusListIndexWriteContext(ctx context.Context) 
 
 	var statusListIndex StatusListIndex
 	if err = json.Unmarshal(gotCurrentListIndexBytes, &statusListIndex); err != nil {
-		return nil, util.LoggingErrorMsg(err, "could not unmarshal unique numbers")
+		return nil, util.LoggingErrorMsg(err, "unmarshalling unique numbers")
 	}
 
 	if statusListIndex.Index >= bitStringLength-1 {
@@ -273,7 +273,7 @@ func (cs *Storage) GetStatusListCredential(ctx context.Context, id string) (*Sto
 
 	var stored StoredCredential
 	if err = json.Unmarshal(credBytes, &stored); err != nil {
-		return nil, util.LoggingErrorMsgf(err, "could not unmarshal stored credential: %s", id)
+		return nil, util.LoggingErrorMsgf(err, "unmarshalling stored credential: %s", id)
 	}
 	return &stored, nil
 }
@@ -381,7 +381,7 @@ func (cs *Storage) getCredential(ctx context.Context, id string, namespace strin
 
 	var stored StoredCredential
 	if err = json.Unmarshal(credBytes, &stored); err != nil {
-		return nil, util.LoggingErrorMsgf(err, "could not unmarshal stored credential: %s", id)
+		return nil, util.LoggingErrorMsgf(err, "unmarshalling stored credential: %s", id)
 	}
 	return &stored, nil
 }
@@ -419,7 +419,7 @@ func (cs *Storage) GetCredentialsByIssuer(ctx context.Context, issuer string) ([
 		} else {
 			var cred StoredCredential
 			if err = json.Unmarshal(credBytes, &cred); err != nil {
-				logrus.WithError(err).Errorf("could not unmarshal credential with key: %s", key)
+				logrus.WithError(err).Errorf("unmarshalling credential with key: %s", key)
 			}
 			storedCreds = append(storedCreds, cred)
 		}
@@ -462,7 +462,7 @@ func (cs *Storage) GetCredentialsBySubject(ctx context.Context, subject string) 
 		} else {
 			var cred StoredCredential
 			if err := json.Unmarshal(credBytes, &cred); err != nil {
-				logrus.WithError(err).Errorf("could not unmarshal credential with key: %s", key)
+				logrus.WithError(err).Errorf("unmarshalling credential with key: %s", key)
 			}
 			storedCreds = append(storedCreds, cred)
 		}
@@ -506,7 +506,7 @@ func (cs *Storage) GetCredentialsBySchema(ctx context.Context, schema string) ([
 		} else {
 			var cred StoredCredential
 			if err := json.Unmarshal(credBytes, &cred); err != nil {
-				logrus.WithError(err).Errorf("could not unmarshal credential with key: %s", key)
+				logrus.WithError(err).Errorf("unmarshalling credential with key: %s", key)
 			}
 			storedCreds = append(storedCreds, cred)
 		}
@@ -554,7 +554,7 @@ func (cs *Storage) GetStatusListCredentialsByIssuerAndSchema(ctx context.Context
 		} else {
 			var cred StoredCredential
 			if err = json.Unmarshal(credBytes, &cred); err != nil {
-				logrus.WithError(err).Errorf("could not unmarshal credential with key: %s", key)
+				logrus.WithError(err).Errorf("unmarshalling credential with key: %s", key)
 			}
 
 			storedCreds = append(storedCreds, cred)
@@ -596,7 +596,7 @@ func (cs *Storage) getCredentialsByIssuerAndSchema(ctx context.Context, issuer s
 		} else {
 			var cred StoredCredential
 			if err = json.Unmarshal(credBytes, &cred); err != nil {
-				logrus.WithError(err).Errorf("could not unmarshal credential with key: %s", key)
+				logrus.WithError(err).Errorf("unmarshalling credential with key: %s", key)
 			}
 			storedCreds = append(storedCreds, cred)
 		}


### PR DESCRIPTION
# Overview
This change allows the ssi-service to have suspension credentials

# Description
Following the status list spec https://w3c.github.io/vc-status-list-2021/ we now have support for revocable and suspendable credentials. This change enforces and assumes that any one credential can only be revocable OR suspendable and not both. This fits the spec as in the example there is only room for one credentialStatus object and not an array

```
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://w3id.org/vc/status-list/2021/v1"
  ],
  "id": "https://example.com/credentials/23894672394",
  "type": ["VerifiableCredential"],
  "issuer": "did:example:12345",
  "issued": "2021-04-05T14:27:42Z",
  "credentialStatus": {
    "id": "https://example.com/credentials/status/3#94567"
    "type": "StatusList2021Entry",
    "statusPurpose": "revocation",
    "statusListIndex": "94567",
    "statusListCredential": "https://example.com/credentials/status/3"
  },
  "credentialSubject": {
    "id": "did:example:6789",
    "type": "Person"
  },
  "proof": { ... }
}
```

 
The StatusListCredential are now unique to 3 fields <issuer,schema,statusPurpose>
issuer1,schema1,revocation = StatusList2021Credential1
issuer1,schema1,suspension = StatusList2021Credential2
