### PR TITLE
Adding Wellknown Generation utility

### DIFF
--- a/pkg/testutil/well_known_generation_test.go
+++ b/pkg/testutil/well_known_generation_test.go
@@ -1,0 +1,194 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	credsdk "github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/goccy/go-json"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tbd54566975/ssi-service/config"
+	"github.com/tbd54566975/ssi-service/internal/keyaccess"
+	"github.com/tbd54566975/ssi-service/pkg/service/did"
+	"github.com/tbd54566975/ssi-service/pkg/service/keystore"
+	"github.com/tbd54566975/ssi-service/pkg/storage"
+)
+
+func TestWellKnownGeneration(t *testing.T) {
+
+	t.Run("Credential .WellKnown Credential Test", func(tt *testing.T) {
+		// To generate a well known config remove this line
+		tt.Skip("skipping wellknown test")
+
+		origin := "https://www.tbd.website/"
+		bolt := setupTestDB(tt)
+		keyStoreService := testKeyStoreService(tt, bolt)
+		didService := testDIDService(tt, bolt, keyStoreService)
+
+		didKey, err := didService.CreateDIDByMethod(context.Background(), did.CreateDIDRequest{Method: "key", KeyType: "Ed25519"})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, didKey)
+
+		gotKey, err := keyStoreService.GetKey(context.Background(), keystore.GetKeyRequest{ID: didKey.DID.ID})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, gotKey)
+
+		createWellKnownDIDConfiguration(tt, didKey, gotKey, origin)
+
+		didWeb, err := didService.CreateDIDByMethod(context.Background(), did.CreateDIDRequest{Method: "web", DIDWebID: "did:web:tbd.website", KeyType: "Ed25519"})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, didWeb)
+
+		gotDidWebKey, err := keyStoreService.GetKey(context.Background(), keystore.GetKeyRequest{ID: didWeb.DID.ID})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, gotDidWebKey)
+
+		createWellKnownDIDConfiguration(tt, didWeb, gotDidWebKey, origin)
+	})
+}
+
+func createWellKnownDIDConfiguration(tt *testing.T, didResponse *did.CreateDIDResponse, gotKey *keystore.GetKeyResponse, origin string) {
+	builder := credsdk.NewVerifiableCredentialBuilder()
+
+	err := builder.SetIssuer(didResponse.DID.ID)
+	assert.NoError(tt, err)
+
+	subjectData := map[string]interface{}{
+		"id":     didResponse.DID.ID,
+		"origin": origin,
+	}
+
+	subject := credsdk.CredentialSubject(subjectData)
+	err = builder.SetCredentialSubject(subject)
+	assert.NoError(tt, err)
+
+	err = builder.AddContext("https://identity.foundation/.well-known/did-configuration/v1")
+	assert.NoError(tt, err)
+
+	err = builder.SetExpirationDate("2051-10-05T14:48:00.000Z")
+
+	err = builder.SetIssuanceDate(time.Now().Format(time.RFC3339))
+	assert.NoError(tt, err)
+
+	err = builder.AddType("DomainLinkageCredential")
+	assert.NoError(tt, err)
+
+	builder.SetID("")
+	cred, err := builder.Build()
+	assert.NoError(tt, err)
+
+	keyAccess, err := keyaccess.NewJWKKeyAccess(gotKey.ID, gotKey.Key)
+
+	jwtToken := jwt.New()
+
+	expirationVal := cred.ExpirationDate
+	if expirationVal != "" {
+		var expirationDate = expirationVal
+		unixTime, err := rfc3339ToUnix(expirationVal)
+		assert.NoError(tt, err)
+		expirationDate = string(unixTime)
+		err = jwtToken.Set(jwt.ExpirationKey, expirationDate)
+		assert.NoError(tt, err)
+	}
+
+	err = jwtToken.Set(jwt.IssuerKey, cred.Issuer)
+
+	var issuanceDate = cred.IssuanceDate
+	if unixTime, err := rfc3339ToUnix(cred.IssuanceDate); err == nil {
+		issuanceDate = string(unixTime)
+	} else {
+		// could not convert iat to unix time; setting to present moment
+		issuanceDate = strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+	}
+
+	err = jwtToken.Set(jwt.NotBeforeKey, issuanceDate)
+
+	subVal := cred.CredentialSubject.GetID()
+	if subVal != "" {
+		err = jwtToken.Set(jwt.SubjectKey, subVal)
+		assert.NoError(tt, err)
+	}
+
+	VCJWTProperty := "vc"
+	err = jwtToken.Set(VCJWTProperty, cred)
+	assert.NoError(tt, err)
+
+	// TODO: Remove typ header
+	//option := jwt.WithJwsHeaders()
+	signedTokenBytes, err := jwt.Sign(jwtToken, jwa.SignatureAlgorithm(keyAccess.JWTSigner.GetSigningAlgorithm()), keyAccess.JWTSigner.Key)
+
+	credToken := keyaccess.JWT(signedTokenBytes).Ptr()
+
+	wellKnown := map[string]interface{}{
+		"@context":    "https://identity.foundation/.well-known/did-configuration/v1",
+		"linked_dids": []string{credToken.String()},
+	}
+
+	jsonStr, _ := json.Marshal(wellKnown)
+
+	fmt.Println("Created Well Known Output for DID:")
+	fmt.Println(didResponse.DID.ID)
+
+	fmt.Println("DID Private Key:")
+	fmt.Println(didResponse.PrivateKeyBase58)
+
+	fmt.Println("Well Known Config:")
+	fmt.Println(string(jsonStr))
+}
+
+func testKeyStoreService(t *testing.T, db storage.ServiceStorage) *keystore.Service {
+	serviceConfig := config.KeyStoreServiceConfig{ServiceKeyPassword: "test-password"}
+	// create a keystore service
+	keystoreService, err := keystore.NewKeyStoreService(serviceConfig, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, keystoreService)
+	return keystoreService
+}
+
+func testDIDService(t *testing.T, db storage.ServiceStorage, keyStore *keystore.Service) *did.Service {
+	serviceConfig := config.DIDServiceConfig{
+		BaseServiceConfig: &config.BaseServiceConfig{
+			Name: "did",
+		},
+		Methods:           []string{"key", "web"},
+		ResolutionMethods: []string{"key"},
+	}
+	// create a did service
+	didService, err := did.NewDIDService(serviceConfig, db, keyStore)
+	require.NoError(t, err)
+	require.NotEmpty(t, didService)
+	return didService
+}
+
+func setupTestDB(t *testing.T) storage.ServiceStorage {
+	file, err := os.CreateTemp("", "bolt")
+	require.NoError(t, err)
+	name := file.Name()
+	file.Close()
+	s, err := storage.NewStorage(storage.Bolt, name)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = s.Close()
+		_ = os.Remove(s.URI())
+	})
+	return s
+}
+
+// according to the spec the JWT timestamp must be a `NumericDate` property, which is a JSON Unix timestamp value.
+// https://www.w3.org/TR/vc-data-model/#json-web-token
+// https://datatracker.ietf.org/doc/html/rfc7519#section-2
+func rfc3339ToUnix(timestamp string) ([]byte, error) {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	unixTimestampInt := strconv.FormatInt(t.Unix(), 10)
+	return []byte(unixTimestampInt), nil
+}


### PR DESCRIPTION
# Overview
This is an ssi-service utility to create a wellknown configuration in accordance with the spec here - https://identity.foundation/.well-known/resources/did-configuration/#DomainLinkageCredential

# Description
It will be a integrated feature in the ssi-service in the future but for now we are smoketesting this feature

# Output generated

DID KEY - did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v 
Private key "-removed-"
```
{
   "@context":"https://identity.foundation/.well-known/did-configuration/v1",
   "linked_dids":[
      "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa2g0QTZRVE5DQUZpNE5aZm5XdDhxTlNHWERHbk5YaHhYV2V3Y3BCcnpTMTl2IiwidHlwIjoiSldUIn0.eyJleHAiOjI1ODAxMzAwODAsImlzcyI6ImRpZDprZXk6ejZNa2g0QTZRVE5DQUZpNE5aZm5XdDhxTlNHWERHbk5YaHhYV2V3Y3BCcnpTMTl2IiwibmJmIjoxNjc2NTcyMDkzLCJzdWIiOiJkaWQ6a2V5Ono2TWtoNEE2UVROQ0FGaTROWmZuV3Q4cU5TR1hER25OWGh4WFdld2NwQnJ6UzE5diIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly9pZGVudGl0eS5mb3VuZGF0aW9uLy53ZWxsLWtub3duL2RpZC1jb25maWd1cmF0aW9uL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJEb21haW5MaW5rYWdlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJkaWQ6a2V5Ono2TWtoNEE2UVROQ0FGaTROWmZuV3Q4cU5TR1hER25OWGh4WFdld2NwQnJ6UzE5diIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDItMTZUMTI6Mjg6MTMtMDY6MDAiLCJleHBpcmF0aW9uRGF0ZSI6IjIwNTEtMTAtMDVUMTQ6NDg6MDAuMDAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1raDRBNlFUTkNBRmk0Tlpmbld0OHFOU0dYREduTlhoeFhXZXdjcEJyelMxOXYiLCJvcmlnaW4iOiJodHRwczovL3d3dy50YmQud2Vic2l0ZS8ifX19.szn9o_JhCLqYMH_SNtwFaJWViueg-pvrZW4G88cegh2Airh9ziQ7fYvSY4Hts2FlF6at8fMfAzrsnhJ-Fb0_Dw"
   ]
}
```

DID WEB - did:web:tbd.website 
Private key "-removed-"
```
{
   "@context":"https://identity.foundation/.well-known/did-configuration/v1",
   "linked_dids":[
      "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6dGJkLndlYnNpdGUiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjI1ODAxMzAwODAsImlzcyI6ImRpZDp3ZWI6dGJkLndlYnNpdGUiLCJuYmYiOjE2NzY1NzIwOTUsInN1YiI6ImRpZDp3ZWI6dGJkLndlYnNpdGUiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vaWRlbnRpdHkuZm91bmRhdGlvbi8ud2VsbC1rbm93bi9kaWQtY29uZmlndXJhdGlvbi92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRG9tYWluTGlua2FnZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjp0YmQud2Vic2l0ZSIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDItMTZUMTI6Mjg6MTUtMDY6MDAiLCJleHBpcmF0aW9uRGF0ZSI6IjIwNTEtMTAtMDVUMTQ6NDg6MDAuMDAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOndlYjp0YmQud2Vic2l0ZSIsIm9yaWdpbiI6Imh0dHBzOi8vd3d3LnRiZC53ZWJzaXRlLyJ9fX0.bweamOE6q-K1jQ64cfqk-vhhuugSpLvcit3Q6REBM2z0CpvvTX4SttHF533oUIDovtOSqmAAOOUFCbrTJYQfDw"
   ]
}
```

# Decoded Comparison To Spec:

SPEC Example:
spec
```
{
  "alg": "EdDSA",
  "kid": "did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM#z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM"
}

{
  "exp": 1764879139,
  "iss": "did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM",
  "nbf": 1607112739,
  "sub": "did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM",
  "vc": {
    "@context": [
      "https://www.w3.org/2018/credentials/v1",
      "https://identity.foundation/.well-known/did-configuration/v1"
    ],
    "credentialSubject": {
      "id": "did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM",
      "origin": "identity.foundation"
    },
    "expirationDate": "2025-12-04T14:12:19-06:00",
    "issuanceDate": "2020-12-04T14:12:19-06:00",
    "issuer": "did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM",
    "type": [
      "VerifiableCredential",
      "DomainLinkageCredential"
    ]
  }
}
```

DID KEY Example payload decoded
```
{
  "alg": "EdDSA",
  "kid": "did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v",
  "typ": "JWT"
}

{
  "exp": 2580130080,
  "iss": "did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v",
  "nbf": 1676572093,
  "sub": "did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v",
  "vc": {
    "@context": [
      "https://www.w3.org/2018/credentials/v1",
      "https://identity.foundation/.well-known/did-configuration/v1"
    ],
    "type": [
      "VerifiableCredential",
      "DomainLinkageCredential"
    ],
    "issuer": "did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v",
    "issuanceDate": "2023-02-16T12:28:13-06:00",
    "expirationDate": "2051-10-05T14:48:00.000Z",
    "credentialSubject": {
      "id": "did:key:z6Mkh4A6QTNCAFi4NZfnWt8qNSGXDGnNXhxXWewcpBrzS19v",
      "origin": "https://www.tbd.website/"
    }
  }
}

```

# Things to Note
In the header to be fully compliant we will need to remove  "typ": "JWT" from our generation script
