### PR TITLE
added utility on new key store service from keystorage

### DIFF
--- a/pkg/service/keystore/service.go
+++ b/pkg/service/keystore/service.go
@@ -46,6 +46,18 @@ func (s Service) Config() config.KeyStoreServiceConfig {
 	return s.config
 }
 
+// NewKeyStoreFromKeystoreStorage uses  a keystore service directly from storage object
+func NewKeyStoreFromKeystoreStorage(config config.KeyStoreServiceConfig, keyStoreStorage *Storage) (*Service, error) {
+	service := Service{
+		storage: keyStoreStorage,
+		config:  config,
+	}
+	if !service.Status().IsReady() {
+		return nil, errors.New(service.Status().Message)
+	}
+	return &service, nil
+}
+
 func NewKeyStoreService(config config.KeyStoreServiceConfig, s storage.ServiceStorage) (*Service, error) {
 	// First, generate a service key
 	serviceKey, serviceKeySalt, err := GenerateServiceKey(config.ServiceKeyPassword)


### PR DESCRIPTION
# Overview
Helper to build a keystorage service form an existing keystore.

# Description
I wanted to use an existing keystore.keyStorage for `ssi-service`. The main issue is that https://github.com/TBD54566975/ssi-service/blob/main/pkg/service/keystore/service.go#L51 generates a new service key, and I wanted to read an existing service key stored in a db. It wasn't clear how to spin up a KeystoreService with an existing ServiceKey, and the storage and config methods are privately scoped, so other applications can't read it. Therefore, I decided to add a helper method that adds a way to create a new keystore service with an existing storage configuration. 

# How Has This Been Tested?
I've confirmed this function works, and tested locally, but haven't built any tests for CI/CD. We are hanging ~24% test coverage right now, so not sure if a test is required, but can add one it if that is a requirement for merge. 

# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages
