### PR TITLE
Added Key Exists API

### DIFF
--- a/pkg/server/router/keystore.go
+++ b/pkg/server/router/keystore.go
@@ -161,3 +161,33 @@ func (ksr *KeyStoreRouter) DeleteKey(ctx context.Context, w http.ResponseWriter,
 	resp := GetKeyDetailsResponse{}
 	return framework.Respond(ctx, w, resp, http.StatusOK)
 }
+
+// KeyExists godoc
+//
+// @Summary     Check Key Id Exists
+// @Description Check a key exists without disclosing key contents
+// @Tags        KeyStoreAPI
+// @Accept      json
+// @Produce     json
+// @Param       id  path     string true "ID"
+// @Success     200 {object} KeyExistsResponse
+// @Failure     400 {string} string "Bad request"
+// @Router      /v1/keys/check/{id} [get]
+func (ksr *KeyStoreRouter) KeyExists(ctx context.Context, w http.ResponseWriter, _ *http.Request) error {
+	id := framework.GetParam(ctx, IDParam)
+	if id == nil {
+		errMsg := "cannot check key exists without ID parameter"
+		logrus.Error(errMsg)
+		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+	}
+
+	_, err := ksr.service.KeyExists(ctx, keystore.KeyExistsRequest{ID: *id})
+	if err != nil {
+		errMsg := fmt.Sprintf("could not check key for id: %s", *id)
+		logrus.WithError(err).Error(errMsg)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
+	}
+
+	resp := GetKeyDetailsResponse{}
+	return framework.Respond(ctx, w, resp, http.StatusOK)
+}

--- a/pkg/server/router/keystore.go
+++ b/pkg/server/router/keystore.go
@@ -131,3 +131,33 @@ func (ksr *KeyStoreRouter) GetKeyDetails(ctx context.Context, w http.ResponseWri
 	}
 	return framework.Respond(ctx, w, resp, http.StatusOK)
 }
+
+// DeleteKey godoc
+//
+// @Summary     Delete Key
+// @Description Delete a stored key
+// @Tags        KeyStoreAPI
+// @Accept      json
+// @Produce     json
+// @Param       id  path     string true "ID"
+// @Success     200 {object} DeleteKeyResponse
+// @Failure     400 {string} string "Bad request"
+// @Router      /v1/keys/{id} [delete]
+func (ksr *KeyStoreRouter) DeleteKey(ctx context.Context, w http.ResponseWriter, _ *http.Request) error {
+	id := framework.GetParam(ctx, IDParam)
+	if id == nil {
+		errMsg := "cannot delete key without ID parameter"
+		logrus.Error(errMsg)
+		return framework.NewRequestErrorMsg(errMsg, http.StatusBadRequest)
+	}
+
+	_, err := ksr.service.DeleteKey(ctx, keystore.DeleteKeyRequest{ID: *id})
+	if err != nil {
+		errMsg := fmt.Sprintf("could not delete key for id: %s", *id)
+		logrus.WithError(err).Error(errMsg)
+		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusBadRequest)
+	}
+
+	resp := GetKeyDetailsResponse{}
+	return framework.Respond(ctx, w, resp, http.StatusOK)
+}

--- a/pkg/server/router/keystore_test.go
+++ b/pkg/server/router/keystore_test.go
@@ -86,5 +86,11 @@ func TestKeyStoreRouter(t *testing.T) {
 		assert.Equal(tt, keyID, gotDetails.ID)
 		assert.Equal(tt, crypto.Ed25519, gotDetails.Type)
 		assert.Equal(tt, "did:test:me", gotDetails.Controller)
+
+		// delete key checks
+		_, err = keyStoreService.DeleteKey(context.Background(), keystore.DeleteKeyRequest{ID: keyID})
+		assert.NoError(tt, err)
+		_, err = keyStoreService.GetKeyDetails(context.Background(), keystore.GetKeyDetailsRequest{ID: keyID})
+		assert.Error(tt, err)
 	})
 }

--- a/pkg/service/keystore/model.go
+++ b/pkg/service/keystore/model.go
@@ -35,3 +35,10 @@ type GetKeyDetailsResponse struct {
 	Controller string
 	CreatedAt  string
 }
+
+type DeleteKeyRequest struct {
+	ID string
+}
+
+type DeleteKeyResponse struct {
+}

--- a/pkg/service/keystore/model.go
+++ b/pkg/service/keystore/model.go
@@ -42,3 +42,11 @@ type DeleteKeyRequest struct {
 
 type DeleteKeyResponse struct {
 }
+
+type KeyExistsRequest struct {
+	ID string
+}
+
+type KeyExistsResponse struct {
+	Exists bool
+}

--- a/pkg/service/keystore/service.go
+++ b/pkg/service/keystore/service.go
@@ -143,7 +143,7 @@ func (s Service) GetKey(ctx context.Context, request GetKeyRequest) (*GetKeyResp
 }
 
 func (s Service) DeleteKey(ctx context.Context, request DeleteKeyRequest) (*DeleteKeyResponse, error) {
-	logrus.Debugf("deleteing key: %+v", request)
+	logrus.Debugf("deleting key: %+v", request)
 	id := request.ID
 	err := s.storage.DeleteKey(ctx, id)
 	if err != nil {
@@ -151,6 +151,15 @@ func (s Service) DeleteKey(ctx context.Context, request DeleteKeyRequest) (*Dele
 	}
 
 	return &DeleteKeyResponse{}, nil
+}
+
+func (s Service) KeyExists(ctx context.Context, request KeyExistsRequest) (*KeyExistsResponse, error) {
+	id := request.ID
+	resp, err := s.storage.KeyExists(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyExistsResponse{Exists: resp}, nil
 }
 
 func (s Service) GetKeyDetails(ctx context.Context, request GetKeyDetailsRequest) (*GetKeyDetailsResponse, error) {

--- a/pkg/service/keystore/service.go
+++ b/pkg/service/keystore/service.go
@@ -48,6 +48,10 @@ func (s Service) Config() config.KeyStoreServiceConfig {
 
 // NewKeyStoreFromKeystoreStorage uses  a keystore service directly from storage object
 func NewKeyStoreFromKeystoreStorage(config config.KeyStoreServiceConfig, keyStoreStorage *Storage) (*Service, error) {
+	if keyStoreStorage == nil {
+		return nil, errors.New("no storage provided")
+	}
+
 	service := Service{
 		storage: keyStoreStorage,
 		config:  config,

--- a/pkg/service/keystore/service.go
+++ b/pkg/service/keystore/service.go
@@ -46,6 +46,18 @@ func (s Service) Config() config.KeyStoreServiceConfig {
 	return s.config
 }
 
+// NewKeyStoreFromKeystoreStorage uses  a keystore service directly from storage object
+func NewKeyStoreFromKeystoreStorage(config config.KeyStoreServiceConfig, keyStoreStorage *Storage) (*Service, error) {
+	service := Service{
+		storage: keyStoreStorage,
+		config:  config,
+	}
+	if !service.Status().IsReady() {
+		return nil, errors.New(service.Status().Message)
+	}
+	return &service, nil
+}
+
 func NewKeyStoreService(config config.KeyStoreServiceConfig, s storage.ServiceStorage) (*Service, error) {
 	// First, generate a service key
 	serviceKey, serviceKeySalt, err := GenerateServiceKey(config.ServiceKeyPassword)

--- a/pkg/service/keystore/service.go
+++ b/pkg/service/keystore/service.go
@@ -142,6 +142,17 @@ func (s Service) GetKey(ctx context.Context, request GetKeyRequest) (*GetKeyResp
 	}, nil
 }
 
+func (s Service) DeleteKey(ctx context.Context, request DeleteKeyRequest) (*DeleteKeyResponse, error) {
+	logrus.Debugf("deleteing key: %+v", request)
+	id := request.ID
+	err := s.storage.DeleteKey(ctx, id)
+	if err != nil {
+		return nil, util.LoggingErrorMsgf(err, "could not delete key: %s", id)
+	}
+
+	return &DeleteKeyResponse{}, nil
+}
+
 func (s Service) GetKeyDetails(ctx context.Context, request GetKeyDetailsRequest) (*GetKeyDetailsResponse, error) {
 
 	logrus.Debugf("getting key: %+v", request)

--- a/pkg/service/keystore/service_test.go
+++ b/pkg/service/keystore/service_test.go
@@ -167,7 +167,7 @@ func TestStoreAndGetKeyWithExistingKeystorage(t *testing.T) {
 	serviceKey, serviceKeySalt, err := GenerateServiceKey(config.ServiceKeyPassword)
 
 	// Next, instantiate the key storage
-	keyStoreStorage, err := NewKeyStoreStorage(s, ServiceKey{
+	keyStoreStorage, err := NewKeyStoreStorage(bolt, ServiceKey{
 		Base58Key:  serviceKey,
 		Base58Salt: serviceKeySalt,
 	})

--- a/pkg/service/keystore/storage.go
+++ b/pkg/service/keystore/storage.go
@@ -125,6 +125,10 @@ func (kss *Storage) StoreKey(ctx context.Context, key StoredKey) error {
 	return kss.db.Write(ctx, namespace, id, encryptedKey)
 }
 
+func (kss *Storage) DeleteKey(ctx context.Context, id string) error {
+	return kss.db.Delete(ctx, namespace, id)
+}
+
 func (kss *Storage) GetKey(ctx context.Context, id string) (*StoredKey, error) {
 	storedKeyBytes, err := kss.db.Read(ctx, namespace, id)
 	if err != nil {

--- a/pkg/service/keystore/storage.go
+++ b/pkg/service/keystore/storage.go
@@ -126,7 +126,24 @@ func (kss *Storage) StoreKey(ctx context.Context, key StoredKey) error {
 }
 
 func (kss *Storage) DeleteKey(ctx context.Context, id string) error {
+	if r, err := kss.KeyExists(ctx, id); err != nil {
+		return err
+	} else if !r {
+		return errors.New("key does not exist.")
+	}
 	return kss.db.Delete(ctx, namespace, id)
+}
+
+// check if a key exists
+func (kss *Storage) KeyExists(ctx context.Context, id string) (bool, error) {
+	storedKeyBytes, err := kss.db.Read(ctx, namespace, id)
+	if err != nil {
+		return false, err
+	}
+	if storedKeyBytes != nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (kss *Storage) GetKey(ctx context.Context, id string) (*StoredKey, error) {

--- a/pkg/storage/bolt.go
+++ b/pkg/storage/bolt.go
@@ -146,8 +146,7 @@ func (b *BoltDB) Read(ctx context.Context, namespace, key string) ([]byte, error
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(namespace))
 		if bucket == nil {
-			logrus.Warnf("namespace<%s> does not exist", namespace)
-			return nil
+			return fmt.Errorf("namespace<%s> does not exist", namespace)
 		}
 		result = bucket.Get([]byte(key))
 		return nil


### PR DESCRIPTION
# Overview
Adds a key exists API. Used to validate a key id exists without disclosing information about the key exists.

Note: This should be merged **after** rebasing against main once https://github.com/TBD54566975/ssi-service/pull/293 has been merged.  I can't move this out of DRAFT until this happens, as there are some dependencies on a #293 

# Description
Simply checks if a key exists in the API backend, without exposing the actual key details itself. 

# How Has This Been Tested?
I will be writing a few tests. Will move out of DRAFT when I do. 
# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages