### PR TITLE
Adding functionality for soft deletion of dids

### DIFF
--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -476,7 +476,7 @@ func (cr CredentialRouter) getCredentialsBySchema(ctx context.Context, schema st
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/credentials/{id} [delete]
@@ -494,5 +494,5 @@ func (cr CredentialRouter) DeleteCredential(ctx context.Context, w http.Response
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }

--- a/pkg/server/router/did.go
+++ b/pkg/server/router/did.go
@@ -222,27 +222,20 @@ type ResolveDIDResponse struct {
 	DIDDocumentMetadata *didsdk.DIDDocumentMetadata   `json:"didDocumentMetadata,omitempty"`
 }
 
-type DeleteDIDByMethodRequest struct {
-	// Identifies the cryptographic algorithm family to use when generating this key.
-	// One of the following: `"Ed25519","X25519","secp256k1","P-224","P-256","P-384","P-521","RSA"`.
-	KeyType crypto.KeyType `json:"keyType" validate:"required"`
-
-	// Required when creating a DID with the `web` did method. E.g. `did:web:identity.foundation`.
-	DIDWebID string `json:"didWebId"`
-}
-
 // SoftDeleteDIDByMethod godoc
-//
+// @Description When this is called with the correct did method and id it will flip the softDelete flag to true for the db entry.
+// @Description A user can still get the did if they know the DID ID, and the did keys will still exist, but this did will not show up in the GetDIDsByMethod call
+// @Description This facilitates a clean SSI-Service Admin UI but not leave any hanging VCs with inaccessible hanging DIDs.
 // @Summary     Soft Delete DID
 // @Description Soft Deletes DID by method
 // @Tags        DecentralizedIdentityAPI
 // @Accept      json
 // @Produce     json
-// @Param       request body     DeleteDIDByMethodRequest true "request body"
 // @Param       method  path     string                   true "Method"
 // @Param       id      path     string                   true "ID"
-// @Success     200     {string} string "OK"
+// @Success     204     {string} string "No Content"
 // @Failure     400     {string} string "Bad request"
+// @Failure     500     {string} string "Internal server error"
 // @Router      /v1/dids/{method}/{id} [delete]
 func (dr DIDRouter) SoftDeleteDIDByMethod(ctx context.Context, w http.ResponseWriter, _ *http.Request) error {
 	method := framework.GetParam(ctx, MethodParam)
@@ -265,7 +258,7 @@ func (dr DIDRouter) SoftDeleteDIDByMethod(ctx context.Context, w http.ResponseWr
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 // ResolveDID godoc

--- a/pkg/server/router/did_test.go
+++ b/pkg/server/router/did_test.go
@@ -95,6 +95,19 @@ func TestDIDRouter(t *testing.T) {
 			}
 		}
 		assert.Len(tt, knownDIDs, 0)
+
+		// delete dids
+		err = didService.SoftDeleteDIDByMethod(context.Background(), did.DeleteDIDRequest{Method: didsdk.KeyMethod, ID: createDIDResponse.DID.ID})
+		assert.NoError(tt, err)
+
+		err = didService.SoftDeleteDIDByMethod(context.Background(), did.DeleteDIDRequest{Method: didsdk.KeyMethod, ID: createDIDResponse2.DID.ID})
+		assert.NoError(tt, err)
+
+		// get all DIDs back
+		getDIDsResponse, err = didService.GetDIDsByMethod(context.Background(), did.GetDIDsRequest{Method: didsdk.KeyMethod})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, getDIDsResponse)
+		assert.Len(tt, getDIDsResponse.DIDs, 0)
 	})
 
 	t.Run("DID Web Service Test", func(tt *testing.T) {
@@ -165,5 +178,19 @@ func TestDIDRouter(t *testing.T) {
 			}
 		}
 		assert.Len(tt, knownDIDs, 0)
+
+		// delete dids
+		err = didService.SoftDeleteDIDByMethod(context.Background(), did.DeleteDIDRequest{Method: didsdk.WebMethod, ID: createDIDResponse.DID.ID})
+		assert.NoError(tt, err)
+
+		err = didService.SoftDeleteDIDByMethod(context.Background(), did.DeleteDIDRequest{Method: didsdk.WebMethod, ID: createDIDResponse2.DID.ID})
+		assert.NoError(tt, err)
+
+		// get all DIDs back
+		getDIDsResponse, err = didService.GetDIDsByMethod(context.Background(), did.GetDIDsRequest{Method: didsdk.WebMethod})
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, getDIDsResponse)
+		assert.Len(tt, getDIDsResponse.DIDs, 0)
 	})
+
 }

--- a/pkg/server/router/issuance.go
+++ b/pkg/server/router/issuance.go
@@ -96,7 +96,7 @@ func (ir IssuanceRouter) CreateIssuanceTemplate(ctx context.Context, w http.Resp
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/issuancetemplates/{id} [delete]
@@ -112,7 +112,7 @@ func (ir IssuanceRouter) DeleteIssuanceTemplate(ctx context.Context, w http.Resp
 			util.LoggingErrorMsgf(err, "could not delete issuance template with id: %s", *id), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 type ListIssuanceTemplatesResponse struct {

--- a/pkg/server/router/manifest.go
+++ b/pkg/server/router/manifest.go
@@ -194,7 +194,7 @@ func (mr ManifestRouter) GetManifests(ctx context.Context, w http.ResponseWriter
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/manifests/{id} [delete]
@@ -212,7 +212,7 @@ func (mr ManifestRouter) DeleteManifest(ctx context.Context, w http.ResponseWrit
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 type SubmitApplicationRequest struct {
@@ -407,7 +407,7 @@ func (mr ManifestRouter) GetApplications(ctx context.Context, w http.ResponseWri
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/manifests/applications/{id} [delete]
@@ -425,7 +425,7 @@ func (mr ManifestRouter) DeleteApplication(ctx context.Context, w http.ResponseW
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 type GetResponseResponse struct {

--- a/pkg/server/router/presentation.go
+++ b/pkg/server/router/presentation.go
@@ -216,7 +216,7 @@ func (pr PresentationRouter) ListDefinitions(ctx context.Context, w http.Respons
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/presentation/definition/{id} [delete]
@@ -234,7 +234,7 @@ func (pr PresentationRouter) DeleteDefinition(ctx context.Context, w http.Respon
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 type CreateSubmissionRequest struct {

--- a/pkg/server/router/schema.go
+++ b/pkg/server/router/schema.go
@@ -197,7 +197,7 @@ func (sr SchemaRouter) VerifySchema(ctx context.Context, w http.ResponseWriter, 
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/schemas/{id} [delete]
@@ -215,5 +215,5 @@ func (sr SchemaRouter) DeleteSchema(ctx context.Context, w http.ResponseWriter, 
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }

--- a/pkg/server/router/webhook.go
+++ b/pkg/server/router/webhook.go
@@ -156,7 +156,7 @@ func (wr WebhookRouter) GetWebhooks(ctx context.Context, w http.ResponseWriter, 
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "ID"
-// @Success     200 {string} string "OK"
+// @Success     204 {string} string "No Content"
 // @Failure     400 {string} string "Bad request"
 // @Failure     500 {string} string "Internal server error"
 // @Router      /v1/webhooks/{id} [delete]
@@ -174,7 +174,7 @@ func (wr WebhookRouter) DeleteWebhook(ctx context.Context, w http.ResponseWriter
 		return framework.NewRequestError(errors.Wrap(err, errMsg), http.StatusInternalServerError)
 	}
 
-	return framework.Respond(ctx, w, nil, http.StatusOK)
+	return framework.Respond(ctx, w, nil, http.StatusNoContent)
 }
 
 // GetSupportedNouns godoc

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -134,6 +134,7 @@ func (s *SSIServer) DecentralizedIdentityAPI(service svcframework.Service) (err 
 	s.Handle(http.MethodPut, path.Join(handlerPath, "/:method"), didRouter.CreateDIDByMethod)
 	s.Handle(http.MethodGet, path.Join(handlerPath, "/:method"), didRouter.GetDIDsByMethod)
 	s.Handle(http.MethodGet, path.Join(handlerPath, "/:method/:id"), didRouter.GetDIDByMethod)
+	s.Handle(http.MethodDelete, path.Join(handlerPath, "/:method/:id"), didRouter.SoftDeleteDIDByMethod)
 
 	s.Handle(http.MethodGet, path.Join(path.Join(handlerPath, ResolverPrefix), "/:id"), didRouter.ResolveDID)
 	return

--- a/pkg/server/server_did_test.go
+++ b/pkg/server/server_did_test.go
@@ -177,9 +177,6 @@ func TestDIDAPI(t *testing.T) {
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "could not soft delete DID")
 
-		// reset recorder between calls
-		w.Flush()
-
 		// good method, bad id
 		badParams1 := map[string]string{
 			"method": "key",
@@ -189,8 +186,6 @@ func TestDIDAPI(t *testing.T) {
 		assert.Error(tt, err)
 		assert.Contains(tt, err.Error(), "could not soft delete DID with id: worse: error getting DID: worse")
 
-		// reset recorder between calls
-		w.Flush()
 		// store a DID
 		createDIDRequest := router.CreateDIDByMethodRequest{KeyType: crypto.Ed25519}
 		requestReader := newRequestValue(tt, createDIDRequest)
@@ -203,9 +198,6 @@ func TestDIDAPI(t *testing.T) {
 		var createdDID router.CreateDIDByMethodResponse
 		err = json.NewDecoder(w.Body).Decode(&createdDID)
 		assert.NoError(tt, err)
-
-		// reset recorder between calls
-		w.Flush()
 
 		// get all dids for method
 		req = httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/dids/key", requestReader)
@@ -242,10 +234,6 @@ func TestDIDAPI(t *testing.T) {
 		err = didService.SoftDeleteDIDByMethod(newRequestContextWithParams(goodParams), w, req)
 		assert.NoError(tt, err)
 
-		var delResp router.DeleteDIDByMethodRequest
-		err = json.NewDecoder(w.Body).Decode(&delResp)
-		assert.NoError(tt, err)
-
 		// get it back
 		req = httptest.NewRequest(http.MethodGet, getDIDPath, nil)
 
@@ -256,9 +244,6 @@ func TestDIDAPI(t *testing.T) {
 		err = json.NewDecoder(w.Body).Decode(&deletedGetResp)
 		assert.NoError(tt, err)
 		assert.Equal(tt, createdID, deletedGetResp.DID.ID)
-
-		// reset recorder between calls
-		w.Flush()
 
 		// get all dids for method
 		req = httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/dids/key", requestReader)

--- a/pkg/service/did/key.go
+++ b/pkg/service/did/key.go
@@ -41,8 +41,9 @@ func (h *keyDIDHandler) CreateDID(ctx context.Context, request CreateDIDRequest)
 	// store metadata in DID storage
 	id := doc.String()
 	storedDID := StoredDID{
-		ID:  id,
-		DID: *expanded,
+		ID:          id,
+		DID:         *expanded,
+		SoftDeleted: false,
 	}
 	if err = h.storage.StoreDID(ctx, storedDID); err != nil {
 		return nil, errors.Wrap(err, "could not store did:key value")
@@ -99,7 +100,26 @@ func (h *keyDIDHandler) GetDIDs(ctx context.Context, method did.Method) (*GetDID
 	}
 	dids := make([]did.DIDDocument, 0, len(gotDIDs))
 	for _, gotDID := range gotDIDs {
-		dids = append(dids, gotDID.DID)
+		if !gotDID.SoftDeleted {
+			dids = append(dids, gotDID.DID)
+		}
 	}
 	return &GetDIDsResponse{DIDs: dids}, nil
+}
+
+func (h *keyDIDHandler) SoftDeleteDID(ctx context.Context, request DeleteDIDRequest) error {
+	logrus.Debugf("soft deleting DID: %+v", request)
+
+	id := request.ID
+	gotStoredDID, err := h.storage.GetDID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("error getting DID: %s", id)
+	}
+	if gotStoredDID == nil {
+		return fmt.Errorf("did with id<%s> could not be found", id)
+	}
+
+	gotStoredDID.SoftDeleted = true
+
+	return h.storage.StoreDID(ctx, *gotStoredDID)
 }

--- a/pkg/service/did/model.go
+++ b/pkg/service/did/model.go
@@ -51,3 +51,8 @@ type GetDIDsRequest struct {
 type GetDIDsResponse struct {
 	DIDs []didsdk.DIDDocument `json:"dids"`
 }
+
+type DeleteDIDRequest struct {
+	Method didsdk.Method `json:"method" validate:"required"`
+	ID     string        `json:"id" validate:"required"`
+}

--- a/pkg/service/did/service.go
+++ b/pkg/service/did/service.go
@@ -117,6 +117,7 @@ type MethodHandler interface {
 	CreateDID(ctx context.Context, request CreateDIDRequest) (*CreateDIDResponse, error)
 	GetDID(ctx context.Context, request GetDIDRequest) (*GetDIDResponse, error)
 	GetDIDs(ctx context.Context, method didsdk.Method) (*GetDIDsResponse, error)
+	SoftDeleteDID(ctx context.Context, request DeleteDIDRequest) error
 }
 
 func (s *Service) instantiateHandlerForMethod(method didsdk.Method) error {
@@ -190,6 +191,14 @@ func (s *Service) GetDIDsByMethod(ctx context.Context, request GetDIDsRequest) (
 		return nil, util.LoggingErrorMsgf(err, "could not get handler for method<%s>", method)
 	}
 	return handler.GetDIDs(ctx, method)
+}
+
+func (s *Service) SoftDeleteDIDByMethod(ctx context.Context, request DeleteDIDRequest) error {
+	handler, err := s.getHandler(request.Method)
+	if err != nil {
+		return util.LoggingErrorMsgf(err, "could not get handler for method<%s>", request.Method)
+	}
+	return handler.SoftDeleteDID(ctx, request)
 }
 
 func (s *Service) getHandler(method didsdk.Method) (MethodHandler, error) {

--- a/pkg/service/did/storage.go
+++ b/pkg/service/did/storage.go
@@ -27,8 +27,9 @@ var (
 )
 
 type StoredDID struct {
-	ID  string          `json:"id"`
-	DID did.DIDDocument `json:"did"`
+	ID          string          `json:"id"`
+	DID         did.DIDDocument `json:"did"`
+	SoftDeleted bool            `json:"softDeleted"`
 }
 
 type Storage struct {

--- a/pkg/service/did/web.go
+++ b/pkg/service/did/web.go
@@ -53,8 +53,9 @@ func (h *webDIDHandler) CreateDID(ctx context.Context, request CreateDIDRequest)
 	// store metadata in DID storage
 	id := didWeb.String()
 	storedDID := StoredDID{
-		ID:  id,
-		DID: *doc,
+		ID:          id,
+		DID:         *doc,
+		SoftDeleted: false,
 	}
 	if err = h.storage.StoreDID(ctx, storedDID); err != nil {
 		return nil, errors.Wrap(err, "could not store did:web value")
@@ -111,7 +112,26 @@ func (h *webDIDHandler) GetDIDs(ctx context.Context, method did.Method) (*GetDID
 	}
 	dids := make([]did.DIDDocument, 0, len(gotDIDs))
 	for _, gotDID := range gotDIDs {
-		dids = append(dids, gotDID.DID)
+		if !gotDID.SoftDeleted {
+			dids = append(dids, gotDID.DID)
+		}
 	}
 	return &GetDIDsResponse{DIDs: dids}, nil
+}
+
+func (h *webDIDHandler) SoftDeleteDID(ctx context.Context, request DeleteDIDRequest) error {
+	logrus.Debugf("soft deleting DID: %+v", request)
+
+	id := request.ID
+	gotStoredDID, err := h.storage.GetDID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("error getting DID: %s", id)
+	}
+	if gotStoredDID == nil {
+		return fmt.Errorf("did with id<%s> could not be found", id)
+	}
+
+	gotStoredDID.SoftDeleted = true
+
+	return h.storage.StoreDID(ctx, *gotStoredDID)
 }


### PR DESCRIPTION
# Overview
Adding functionality for soft deletion of dids

# Description
This change adds a new endpoint: 
DEL - http://localhost:8080/v1/dids/:method/:id
When this is called with the correct did method and id it will flip the softDelete flag to true for the db entry.

A user can still get the did if they know the DID ID, 
GET - http://localhost:8080/v1/dids/:method/:id ✅ 

But when they get all dids this will not appear
GET - http://localhost:8080/v1/dids/:method ⚠️ 


The reason for this change is to facilitate a clean SSI-Service Admin UI but not leave any hanging VCs with unaccessible DIDS.
