### PR TITLE
Use published images default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,17 @@ the service, you can use the following command, which will start the service on 
 mage run
 ```
 
-Or, you can run docker-compose yourself:
+Or, you can run docker-compose yourself, building from source:
 ```shell
 cd build && docker-compose up --build
 ```
+
+To use the pre-published images:
+```shell
+cd build && docker-compose up -d
+```
+
+
 
 ## Health and Readiness Checks
 

--- a/build/docker-compose-published.yml
+++ b/build/docker-compose-published.yml
@@ -3,9 +3,7 @@ version: "3.98"
 services:
   web:
     container_name: web
-    build:
-      context: ../
-      dockerfile: build/Dockerfile
+    image: ghcr.io/tbd54566975/ssi-service:main
     ports:
       - "8080:3000"
     environment:
@@ -21,18 +19,14 @@ services:
     links:
       - uni-resolver-web
   swagger-ui:
-    build:
-      context: ../
-      dockerfile: build/Dockerfile-swagger
+    image: ghcr.io/tbd54566975/ssi-service-swagger:main
     ports:
       - "8002:8080"
     volumes:
       - ../doc/swagger.yaml:/app/swagger.yaml
     command: ["serve", "/app/swagger.yaml", "--no-open", "--port", "8080"]
   gui:
-    build:
-      context: ../
-      dockerfile: build/Dockerfile-gui
+    image: ghcr.io/tbd54566975/ssi-service-streamlit:main
     ports:
       - "8003:8501"
     depends_on:

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.98"
 services:
   web:
     container_name: web
+    image: ghcr.io/tbd54566975/ssi-service:main
     build:
       context: ../
       dockerfile: build/Dockerfile
@@ -21,6 +22,7 @@ services:
     links:
       - uni-resolver-web
   swagger-ui:
+    image: ghcr.io/tbd54566975/ssi-service-swagger:main
     build:
       context: ../
       dockerfile: build/Dockerfile-swagger
@@ -30,6 +32,7 @@ services:
       - ../doc/swagger.yaml:/app/swagger.yaml
     command: ["serve", "/app/swagger.yaml", "--no-open", "--port", "8080"]
   gui:
+    image: ghcr.io/tbd54566975/ssi-service-streamlit:main
     build:
       context: ../
       dockerfile: build/Dockerfile-gui


### PR DESCRIPTION
Small change to allow the published images to be used by default when `--build` isn't used for docker compose.