### PR TITLE
Factored request part out of the definition endpoint

### DIFF
--- a/pkg/server/router/presentation.go
+++ b/pkg/server/router/presentation.go
@@ -3,9 +3,11 @@ package router
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/gin-gonic/gin"
 	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
@@ -40,13 +42,6 @@ type CreatePresentationDefinitionRequest struct {
 	Format                 *exchange.ClaimFormat            `json:"format,omitempty" validate:"omitempty,dive"`
 	InputDescriptors       []exchange.InputDescriptor       `json:"inputDescriptors" validate:"required,dive"`
 	SubmissionRequirements []exchange.SubmissionRequirement `json:"submissionRequirements,omitempty" validate:"omitempty,dive"`
-
-	// DID of the author of this presentation definition. The DID must have been previously created with the DID API,
-	// or the PrivateKey must have been added independently.
-	Author string `json:"author" validate:"required"`
-	// The privateKey associated with the KID will be used to sign an envelope that contains
-	// the created presentation definition.
-	AuthorKID string `json:"authorKid" validate:"required"`
 }
 
 type CreatePresentationDefinitionResponse struct {
@@ -86,16 +81,13 @@ func (pr PresentationRouter) CreateDefinition(c *gin.Context) error {
 	}
 	serviceResp, err := pr.service.CreatePresentationDefinition(c, model.CreatePresentationDefinitionRequest{
 		PresentationDefinition: *def,
-		Author:                 request.Author,
-		AuthorKID:              request.AuthorKID,
 	})
 	if err != nil {
 		return framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusInternalServerError)
 	}
 
 	resp := CreatePresentationDefinitionResponse{
-		PresentationDefinition:    serviceResp.PresentationDefinition,
-		PresentationDefinitionJWT: serviceResp.PresentationDefinitionJWT,
+		PresentationDefinition: serviceResp.PresentationDefinition,
 	}
 	return framework.Respond(c, resp, http.StatusCreated)
 }
@@ -133,10 +125,6 @@ func definitionFromRequest(request CreatePresentationDefinitionRequest) (*exchan
 
 type GetPresentationDefinitionResponse struct {
 	PresentationDefinition exchange.PresentationDefinition `json:"presentation_definition,omitempty"`
-
-	// Signed envelope that contains the PresentationDefinition created using the privateKey of the author of the
-	// definition.
-	PresentationDefinitionJWT keyaccess.JWT `json:"presentationDefinitionJWT,omitempty"`
 }
 
 // GetDefinition godoc
@@ -164,8 +152,7 @@ func (pr PresentationRouter) GetDefinition(c *gin.Context) error {
 	}
 
 	resp := GetPresentationDefinitionResponse{
-		PresentationDefinition:    def.PresentationDefinition,
-		PresentationDefinitionJWT: def.PresentationDefinitionJWT,
+		PresentationDefinition: def.PresentationDefinition,
 	}
 	return framework.Respond(c, resp, http.StatusOK)
 }
@@ -227,6 +214,9 @@ func (pr PresentationRouter) DeleteDefinition(c *gin.Context) error {
 }
 
 type CreateSubmissionRequest struct {
+	// A Verifiable Presentation that's encoded as a JWT.
+	// Verifiable Presentation are described in https://www.w3.org/TR/vc-data-model/#presentations-0
+	// JWT encoding of the Presentation as described in https://www.w3.org/TR/vc-data-model/#presentations-0
 	SubmissionJWT keyaccess.JWT `json:"submissionJwt" validate:"required"`
 }
 
@@ -443,4 +433,144 @@ func (pr PresentationRouter) ReviewSubmission(c *gin.Context) error {
 		return framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusInternalServerError)
 	}
 	return framework.Respond(c, ReviewSubmissionResponse{Submission: submission}, http.StatusOK)
+}
+
+const DefaultExpirationDuration = 30 * time.Minute
+
+type CreateRequestRequest struct {
+	// Audience as defined in https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3
+	// Optional
+	Audience []string `json:"audience"`
+
+	// Expiration as defined in https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4
+	// Optional. When not specified, the request will be valid for 30 minutes.
+	Expiration string `json:"expiration"`
+
+	// DID of the issuer of this presentation definition. The DID must have been previously created with the DID API,
+	// or the PrivateKey must have been added independently.
+	IssuerDID string `json:"issuerID" validate:"required"`
+
+	// The privateKey associated with the KID will be used to sign an envelope that contains
+	// the created presentation definition.
+	KID string `json:"kid" validate:"required"`
+
+	// ID of the presentation definition to use for this request.
+	PresentationDefinitionID string `json:"presentationDefinitionId" validate:"required"`
+}
+
+type CreateRequestResponse struct {
+	Request *model.Request `json:"presentationRequest"`
+}
+
+type GetRequestResponse struct {
+	Request *model.Request `json:"presentationRequest"`
+}
+
+// CreateRequest godoc
+//
+// @Summary     Create Presentation Request
+// @Description Create presentation request from an existing presentation definition.
+// @Tags        PresentationRequestAPI
+// @Accept      json
+// @Produce     json
+// @Param       request body     CreateRequestRequest true "request body"
+// @Success     201     {object} CreateRequestResponse
+// @Failure     400     {string} string "Bad request"
+// @Failure     500     {string} string "Internal server error"
+// @Router      /v1/presentation/request [put]
+func (pr PresentationRouter) CreateRequest(c *gin.Context) error {
+	var request CreateRequestRequest
+	errMsg := "Invalid Presentation Request Request"
+	if err := framework.Decode(c.Request, &request); err != nil {
+		return framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusBadRequest)
+	}
+	if err := framework.ValidateRequest(request); err != nil {
+		return framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusBadRequest)
+	}
+
+	req, err := serviceRequestFromRequest(request)
+	if err != nil {
+		return framework.LoggingRespondError(c, err, http.StatusBadRequest)
+	}
+
+	doc, err := pr.service.CreateRequest(c, model.CreateRequestRequest{PresentationRequest: *req})
+	if err != nil {
+		return framework.LoggingRespondError(c, sdkutil.LoggingErrorMsg(err, "signing and storing"), http.StatusInternalServerError)
+	}
+	return framework.Respond(c, CreateRequestResponse{doc}, http.StatusCreated)
+}
+
+func serviceRequestFromRequest(request CreateRequestRequest) (*model.Request, error) {
+	var expiration time.Time
+	var err error
+
+	if request.Expiration != "" {
+		expiration, err = time.Parse(time.RFC3339, request.Expiration)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		expiration = time.Now().Add(DefaultExpirationDuration)
+	}
+
+	return &model.Request{
+		Audience:                 request.Audience,
+		Expiration:               expiration,
+		IssuerDID:                request.IssuerDID,
+		KID:                      request.KID,
+		PresentationDefinitionID: request.PresentationDefinitionID,
+	}, nil
+}
+
+// GetRequest godoc
+//
+// @Summary     Get Presentation Request
+// @Description Get a presentation request by its ID
+// @Tags        PresentationRequestAPI
+// @Accept      json
+// @Produce     json
+// @Param       id  path     string true "ID"
+// @Success     200 {object} GetRequestResponse
+// @Failure     400 {string} string "Bad request"
+// @Router      /v1/presentation/request/{id} [get]
+func (pr PresentationRouter) GetRequest(c *gin.Context) error {
+	id := framework.GetParam(c, IDParam)
+	if id == nil {
+		return framework.LoggingRespondError(c,
+			sdkutil.LoggingNewError("cannot get issuance template without an ID"), http.StatusBadRequest)
+	}
+
+	request, err := pr.service.GetRequest(c, &model.GetRequestRequest{ID: *id})
+	if err != nil {
+		return framework.LoggingRespondError(c,
+			sdkutil.LoggingErrorMsg(err, "getting issuance template"), http.StatusInternalServerError)
+	}
+	return framework.Respond(c, GetRequestResponse{request}, http.StatusOK)
+}
+
+// DeleteRequest godoc
+//
+// @Summary     Delete PresentationRequest
+// @Description Delete a presentation request by its ID
+// @Tags        PresentationRequestAPI
+// @Accept      json
+// @Produce     json
+// @Param       id  path     string true "ID"
+// @Success     204 {string} string "No Content"
+// @Failure     400 {string} string "Bad request"
+// @Failure     500 {string} string "Internal server error"
+// @Router      /v1/presentation/requests/{id} [delete]
+func (pr PresentationRouter) DeleteRequest(c *gin.Context) error {
+	id := framework.GetParam(c, IDParam)
+	if id == nil {
+		errMsg := "cannot delete a presentation request without an ID parameter"
+		return framework.LoggingRespondErrMsg(c, errMsg, http.StatusBadRequest)
+	}
+
+	if err := pr.service.DeleteRequest(c, model.DeleteRequestRequest{ID: *id}); err != nil {
+		errMsg := fmt.Sprintf("could not delete presentation request with id: %s", *id)
+		return framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusInternalServerError)
+	}
+
+	return framework.Respond(c, nil, http.StatusNoContent)
 }

--- a/pkg/server/router/presentation_test.go
+++ b/pkg/server/router/presentation_test.go
@@ -2,15 +2,18 @@ package router
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
+	"github.com/goccy/go-json"
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
@@ -60,38 +63,30 @@ func TestPresentationDefinitionService(t *testing.T) {
 		pd := createPresentationDefinition(t)
 		created, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
 			PresentationDefinition: *pd,
-			Author:                 authorDID.DID.ID,
-			AuthorKID:              authorDID.DID.VerificationMethod[0].ID,
 		})
 
 		assert.NoError(t, err)
 		assert.Equal(t, pd, &created.PresentationDefinition)
-		assert.NoError(t, ka.Verify(created.PresentationDefinitionJWT))
 	})
 
 	t.Run("Get returns the created definition", func(t *testing.T) {
 		pd := createPresentationDefinition(t)
 		_, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
 			PresentationDefinition: *pd,
-			Author:                 authorDID.DID.ID,
-			AuthorKID:              authorDID.DID.VerificationMethod[0].ID,
 		})
 		assert.NoError(t, err)
 
 		getPd, err := service.GetPresentationDefinition(context.Background(), model.GetPresentationDefinitionRequest{ID: pd.ID})
 
 		assert.NoError(t, err)
-		assert.Equal(t, pd.ID, getPd.ID)
+		assert.Equal(t, pd.ID, getPd.PresentationDefinition.ID)
 		assert.Equal(t, pd, &getPd.PresentationDefinition)
-		assert.NoError(t, ka.Verify(getPd.PresentationDefinitionJWT))
 	})
 
 	t.Run("Get does not return after deletion", func(t *testing.T) {
 		pd := createPresentationDefinition(t)
 		_, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
 			PresentationDefinition: *pd,
-			Author:                 authorDID.DID.ID,
-			AuthorKID:              authorDID.DID.VerificationMethod[0].ID,
 		})
 		assert.NoError(t, err)
 
@@ -104,6 +99,114 @@ func TestPresentationDefinitionService(t *testing.T) {
 	t.Run("Delete can be called with any ID", func(t *testing.T) {
 		err := service.DeletePresentationDefinition(context.Background(), model.DeletePresentationDefinitionRequest{ID: "some crazy ID"})
 		assert.NoError(t, err)
+	})
+
+	t.Run("Signed request is return when creating request", func(t *testing.T) {
+		pd := createPresentationDefinition(t)
+		_, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
+			PresentationDefinition: *pd,
+		})
+		assert.NoError(t, err)
+		expectedReq := model.Request{
+			Audience:                 []string{"did:web:heman"},
+			IssuerDID:                authorDID.DID.ID,
+			KID:                      authorDID.DID.VerificationMethod[0].ID,
+			PresentationDefinitionID: pd.ID,
+			Expiration:               time.Date(2023, 10, 10, 10, 10, 10, 0, time.UTC),
+		}
+		req, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: expectedReq,
+		})
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, req.ID)
+		assert.NotEqual(t, req.ID, pd.ID)
+		assert.NoError(t, ka.Verify(req.PresentationDefinitionJWT))
+		payload, err := base64.RawURLEncoding.DecodeString(strings.Split(req.PresentationDefinitionJWT.String(), ".")[1])
+		assert.NoError(t, err)
+		var got exchange.PresentationDefinitionEnvelope
+		assert.NoError(t, json.Unmarshal(payload, &got))
+		assert.Equal(t, *pd, got.PresentationDefinition)
+		assert.Equal(t, expectedReq.Audience, req.Audience)
+		assert.Equal(t, expectedReq.IssuerDID, req.IssuerDID)
+		assert.Equal(t, expectedReq.KID, req.KID)
+		assert.Equal(t, expectedReq.PresentationDefinitionID, req.PresentationDefinitionID)
+		assert.Equal(t, expectedReq.Expiration, req.Expiration)
+	})
+
+	t.Run("Get request returns the created request", func(t *testing.T) {
+		pd := createPresentationDefinition(t)
+		_, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
+			PresentationDefinition: *pd,
+		})
+		assert.NoError(t, err)
+		req, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: model.Request{
+				Audience:                 []string{"did:web:heman"},
+				IssuerDID:                authorDID.DID.ID,
+				KID:                      authorDID.DID.VerificationMethod[0].ID,
+				Expiration:               time.Now().Add(30 * time.Second),
+				PresentationDefinitionID: pd.ID,
+			},
+		})
+		assert.NoError(t, err)
+
+		got, err := service.GetRequest(context.Background(), &model.GetRequestRequest{ID: req.ID})
+		assert.NoError(t, err)
+		assert.Equal(t, req, got)
+	})
+
+	t.Run("Returns not found after deleting request", func(t *testing.T) {
+		pd := createPresentationDefinition(t)
+		_, err := service.CreatePresentationDefinition(context.Background(), model.CreatePresentationDefinitionRequest{
+			PresentationDefinition: *pd,
+		})
+		assert.NoError(t, err)
+		req, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: model.Request{
+				IssuerDID:                authorDID.DID.ID,
+				KID:                      authorDID.DID.VerificationMethod[0].ID,
+				PresentationDefinitionID: pd.ID,
+				Expiration:               time.Now().Add(30 * time.Second),
+			},
+		})
+		assert.NoError(t, err)
+
+		err = service.DeleteRequest(context.Background(), model.DeleteRequestRequest{ID: req.ID})
+		assert.NoError(t, err)
+
+		_, err = service.GetRequest(context.Background(), &model.GetRequestRequest{ID: req.ID})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "presentation request not found")
+	})
+
+	t.Run("Error returned when missing required fields", func(t *testing.T) {
+		_, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: model.Request{
+				IssuerDID: "issuer id",
+				KID:       "kid",
+			},
+		})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed on the 'required' tag")
+
+		_, err = service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: model.Request{
+				IssuerDID:                "issuer id",
+				PresentationDefinitionID: "something",
+			},
+		})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed on the 'required' tag")
+
+		_, err = service.CreateRequest(context.Background(), model.CreateRequestRequest{
+			PresentationRequest: model.Request{
+				KID:                      "kid",
+				PresentationDefinitionID: "something",
+			},
+		})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed on the 'required' tag")
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,7 @@ const (
 	DefinitionsPrefix      = "/definitions"
 	SubmissionsPrefix      = "/submissions"
 	IssuanceTemplatePrefix = "/issuancetemplates"
+	RequestsPrefix         = "/requests"
 	ManifestsPrefix        = "/manifests"
 	ApplicationsPrefix     = "/applications"
 	ResponsesPrefix        = "/responses"
@@ -196,6 +197,12 @@ func (s *SSIServer) PresentationAPI(service svcframework.Service, webhookService
 	s.Handle(http.MethodGet, path.Join(handlerPath, "/:id"), pRouter.GetDefinition)
 	s.Handle(http.MethodGet, handlerPath, pRouter.ListDefinitions)
 	s.Handle(http.MethodDelete, path.Join(handlerPath, "/:id"), pRouter.DeleteDefinition)
+
+	requestHandlerPath := V1Prefix + PresentationsPrefix + RequestsPrefix
+
+	s.Handle(http.MethodPut, requestHandlerPath, pRouter.CreateRequest)
+	s.Handle(http.MethodGet, path.Join(requestHandlerPath, "/:id"), pRouter.GetRequest)
+	s.Handle(http.MethodPut, path.Join(requestHandlerPath, "/:id"), pRouter.DeleteRequest)
 
 	submissionHandlerPath := V1Prefix + PresentationsPrefix + SubmissionsPrefix
 

--- a/pkg/server/server_operation_test.go
+++ b/pkg/server/server_operation_test.go
@@ -28,8 +28,7 @@ func TestOperationsAPI(t *testing.T) {
 		opRouter := setupOperationsRouter(t, s)
 
 		holderSigner, holderDID := getSigner(t)
-		kid := authorDID.DID.VerificationMethod[0].ID
-		definition := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+		definition := createPresentationDefinition(t, pRouter)
 		submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 		sub := reviewSubmission(t, pRouter, opstorage.StatusObjectID(submissionOp.ID))
 
@@ -60,8 +59,7 @@ func TestOperationsAPI(t *testing.T) {
 			opRouter := setupOperationsRouter(t, s)
 
 			holderSigner, holderDID := getSigner(t)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
 			createdID := submissionOp.ID
@@ -124,8 +122,7 @@ func TestOperationsAPI(t *testing.T) {
 			authorDID := createDID(t, didService)
 			opRouter := setupOperationsRouter(t, s)
 
-			kid := authorDID.DID.VerificationMethod[0].ID
-			def := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			def := createPresentationDefinition(t, pRouter)
 			holderSigner, holderDID := getSigner(t)
 			submissionOp := createSubmission(t, pRouter, def.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
@@ -162,8 +159,7 @@ func TestOperationsAPI(t *testing.T) {
 			authorDID := createDID(t, didService)
 			opRouter := setupOperationsRouter(t, s)
 
-			kid := authorDID.DID.VerificationMethod[0].ID
-			def := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			def := createPresentationDefinition(t, pRouter)
 			holderSigner, holderDID := getSigner(t)
 			_ = createSubmission(t, pRouter, def.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
@@ -190,8 +186,7 @@ func TestOperationsAPI(t *testing.T) {
 			authorDID := createDID(t, didService)
 			opRouter := setupOperationsRouter(t, s)
 
-			kid := authorDID.DID.VerificationMethod[0].ID
-			def := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			def := createPresentationDefinition(t, pRouter)
 			holderSigner, holderDID := getSigner(t)
 			_ = createSubmission(t, pRouter, def.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
@@ -217,8 +212,7 @@ func TestOperationsAPI(t *testing.T) {
 			authorDID := createDID(t, didService)
 			opRouter := setupOperationsRouter(t, s)
 
-			kid := authorDID.DID.VerificationMethod[0].ID
-			def := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			def := createPresentationDefinition(t, pRouter)
 			holderSigner, holderDID := getSigner(t)
 			_ = createSubmission(t, pRouter, def.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
@@ -246,8 +240,7 @@ func TestOperationsAPI(t *testing.T) {
 			opRouter := setupOperationsRouter(t, s)
 
 			holderSigner, holderDID := getSigner(t)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
 			createdID := submissionOp.ID
@@ -275,8 +268,7 @@ func TestOperationsAPI(t *testing.T) {
 			opRouter := setupOperationsRouter(t, s)
 
 			holderSigner, holderDID := getSigner(t)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(t, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(t, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 			_ = reviewSubmission(t, pRouter, opstorage.StatusObjectID(submissionOp.ID))
 

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -51,13 +51,11 @@ func TestPresentationAPI(t *testing.T) {
 
 	t.Run("Create, Get, and Delete PresentationDefinition", func(tt *testing.T) {
 		s := setupTestDB(tt)
-		pRouter, didService := setupPresentationRouter(tt, s)
-		authorDID := createDID(tt, didService)
+		pRouter, _ := setupPresentationRouter(tt, s)
 
 		var createdID string
 		{
-			kid := authorDID.DID.VerificationMethod[0].ID
-			resp := createPresentationDefinition(tt, pRouter, authorDID.DID.ID, kid, WithInputDescriptors(inputDescriptors))
+			resp := createPresentationDefinition(tt, pRouter, WithInputDescriptors(inputDescriptors))
 			if diff := cmp.Diff(*pd, resp.PresentationDefinition, cmpopts.IgnoreFields(exchange.PresentationDefinition{}, "ID")); diff != "" {
 				t.Errorf("PresentationDefinition mismatch (-want +got):\n%s", diff)
 			}
@@ -126,11 +124,9 @@ func TestPresentationAPI(t *testing.T) {
 
 	t.Run("List returns many definitions", func(tt *testing.T) {
 		s := setupTestDB(tt)
-		pRouter, didService := setupPresentationRouter(tt, s)
-		authorDID := createDID(tt, didService)
-		kid := authorDID.DID.VerificationMethod[0].ID
-		def1 := createPresentationDefinition(tt, pRouter, authorDID.DID.ID, kid)
-		def2 := createPresentationDefinition(tt, pRouter, authorDID.DID.ID, kid)
+		pRouter, _ := setupPresentationRouter(tt, s)
+		def1 := createPresentationDefinition(tt, pRouter)
+		def2 := createPresentationDefinition(tt, pRouter)
 
 		req := httptest.NewRequest(http.MethodGet, "https://ssi-service.com/v1/presentations/definitions", nil)
 		w := httptest.NewRecorder()
@@ -198,8 +194,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			op := createSubmission(ttt, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(
 				WithCredentialSubject(credential.CredentialSubject{
 					"additionalName": "Mclovin",
@@ -228,8 +223,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			request := createSubmissionRequest(ttt, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(
 				WithCredentialSubject(credential.CredentialSubject{
 					"additionalName": "Mclovin",
@@ -260,8 +254,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 
 			request := router.ReviewSubmissionRequest{
@@ -295,8 +288,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			submissionOp := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(), holderDID, holderSigner)
 			createdID := opstorage.StatusObjectID(submissionOp.ID)
 			_ = reviewSubmission(ttt, pRouter, createdID)
@@ -342,8 +334,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			op := createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(
 				WithCredentialSubject(credential.CredentialSubject{
 					"additionalName": "Mclovin",
@@ -446,8 +437,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			op := createSubmission(ttt, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(
 				WithCredentialSubject(credential.CredentialSubject{
 					"additionalName": "Mclovin",
@@ -503,8 +493,7 @@ func TestPresentationAPI(t *testing.T) {
 			authorDID := createDID(ttt, didService)
 
 			holderSigner, holderDID := getSigner(ttt)
-			kid := authorDID.DID.VerificationMethod[0].ID
-			definition := createPresentationDefinition(ttt, pRouter, authorDID.DID.ID, kid)
+			definition := createPresentationDefinition(ttt, pRouter)
 			_ = createSubmission(t, pRouter, definition.PresentationDefinition.ID, authorDID.DID.ID, VerifiableCredential(
 				WithCredentialSubject(credential.CredentialSubject{
 					"additionalName": "Mclovin",
@@ -643,7 +632,7 @@ func WithInputDescriptors(inputDescriptors []exchange.InputDescriptor) Definitio
 	}
 }
 
-func createPresentationDefinition(t *testing.T, pRouter *router.PresentationRouter, author, authorKID string, opts ...DefinitionOption) router.CreatePresentationDefinitionResponse {
+func createPresentationDefinition(t *testing.T, pRouter *router.PresentationRouter, opts ...DefinitionOption) router.CreatePresentationDefinitionResponse {
 	request := router.CreatePresentationDefinitionRequest{
 		Name:    "name",
 		Purpose: "purpose",
@@ -668,8 +657,6 @@ func createPresentationDefinition(t *testing.T, pRouter *router.PresentationRout
 				},
 			},
 		},
-		Author:    author,
-		AuthorKID: authorKID,
 	}
 	for _, o := range opts {
 		o(&request)

--- a/pkg/service/presentation/model/model.go
+++ b/pkg/service/presentation/model/model.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/TBD54566975/ssi-sdk/util"
@@ -14,8 +16,6 @@ import (
 
 type CreatePresentationDefinitionRequest struct {
 	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition" validate:"required"`
-	Author                 string                          `json:"author" validate:"required"`
-	AuthorKID              string                          `json:"authorKid" validate:"required"`
 }
 
 func (cpr CreatePresentationDefinitionRequest) IsValid() error {
@@ -23,8 +23,7 @@ func (cpr CreatePresentationDefinitionRequest) IsValid() error {
 }
 
 type CreatePresentationDefinitionResponse struct {
-	PresentationDefinition    exchange.PresentationDefinition `json:"presentationDefinition"`
-	PresentationDefinitionJWT keyaccess.JWT                   `json:"presentationDefinitionJWT"`
+	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition"`
 }
 
 type GetPresentationDefinitionRequest struct {
@@ -32,9 +31,7 @@ type GetPresentationDefinitionRequest struct {
 }
 
 type GetPresentationDefinitionResponse struct {
-	ID                        string                          `json:"id"`
-	PresentationDefinition    exchange.PresentationDefinition `json:"presentationDefinition"`
-	PresentationDefinitionJWT keyaccess.JWT                   `json:"presentationDefinitionJWT"`
+	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition"`
 }
 
 type DeletePresentationDefinitionRequest struct {
@@ -123,4 +120,51 @@ func ServiceModel(storedSubmission *storage.StoredSubmission) Submission {
 		Reason:                 storedSubmission.Reason,
 		VerifiablePresentation: &storedSubmission.VerifiablePresentation,
 	}
+}
+
+type CreateRequestRequest struct {
+	PresentationRequest Request `json:"presentationRequest"`
+}
+
+type CreateRequestResponse struct {
+	PresentationRequest Request `json:"presentationRequest"`
+}
+
+type GetRequestRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+type GetRequestResponse struct {
+	ID                  string  `json:"id"`
+	PresentationRequest Request `json:"presentationRequest"`
+}
+
+type DeleteRequestRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+type Request struct {
+	// ID for this request. It matches the "jti" claim in the JWT.
+	// This is an output only field.
+	ID string `json:"id"`
+
+	// Audience as defined in https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3.
+	Audience []string `json:"audience"`
+
+	// Expiration as defined in https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4
+	Expiration time.Time `json:"expiration" validate:"required"`
+
+	// DID of the issuer of this presentation definition.
+	IssuerDID string `json:"issuerID" validate:"required"`
+
+	// The privateKey associated with the KID used to sign the JWT.
+	KID string `json:"kid" validate:"required"`
+
+	// ID of the presentation definition used for this request.
+	PresentationDefinitionID string `json:"presentationDefinitionId" validate:"required"`
+
+	// PresentationDefinitionJWT is a JWT token with a "presentation_definition" claim within it. The
+	// value of the field named "presentation_definition.id" matches PresentationDefinitionID.
+	// This is an output only field.
+	PresentationDefinitionJWT keyaccess.JWT `json:"presentationRequestJwt"`
 }

--- a/pkg/service/presentation/service.go
+++ b/pkg/service/presentation/service.go
@@ -3,18 +3,21 @@ package presentation
 import (
 	"context"
 	"fmt"
+	"time"
 
 	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/TBD54566975/ssi-sdk/did/resolution"
 	sdkutil "github.com/TBD54566975/ssi-sdk/util"
+	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/jws"
+	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/credential"
 	didint "github.com/tbd54566975/ssi-service/internal/did"
+	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 	"github.com/tbd54566975/ssi-service/pkg/service/framework"
 	"github.com/tbd54566975/ssi-service/pkg/service/keystore"
 	"github.com/tbd54566975/ssi-service/pkg/service/operation"
@@ -27,7 +30,7 @@ import (
 )
 
 type Service struct {
-	storage    *Storage
+	storage    presentationstorage.Storage
 	keystore   *keystore.Service
 	opsStorage *operation.Storage
 	config     config.PresentationServiceConfig
@@ -101,25 +104,17 @@ func (s Service) CreatePresentationDefinition(ctx context.Context,
 		return nil, sdkutil.LoggingErrorMsg(err, "provided value is not a valid presentation definition")
 	}
 
-	storedPresentation := StoredPresentation{
+	storedPresentation := presentationstorage.StoredDefinition{
 		ID:                     request.PresentationDefinition.ID,
 		PresentationDefinition: request.PresentationDefinition,
-		Author:                 request.Author,
-		AuthorKID:              request.AuthorKID,
 	}
 
-	if err := s.storage.StorePresentation(ctx, storedPresentation); err != nil {
+	if err := s.storage.StoreDefinition(ctx, storedPresentation); err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not store presentation")
-	}
-	defJWT, err := s.keystore.Sign(context.Background(), storedPresentation.AuthorKID,
-		exchange.PresentationDefinitionEnvelope{PresentationDefinition: storedPresentation.PresentationDefinition})
-	if err != nil {
-		return nil, sdkutil.LoggingErrorMsgf(err, "signing presentation definition enveloper with author<%s>", storedPresentation.Author)
 	}
 
 	var m model.CreatePresentationDefinitionResponse
 	m.PresentationDefinition = storedPresentation.PresentationDefinition
-	m.PresentationDefinitionJWT = *defJWT
 	return &m, nil
 }
 
@@ -127,30 +122,22 @@ func (s Service) GetPresentationDefinition(ctx context.Context,
 	request model.GetPresentationDefinitionRequest) (*model.GetPresentationDefinitionResponse, error) {
 	logrus.Debugf("getting presentation definition: %s", request.ID)
 
-	storedPresentation, err := s.storage.GetPresentation(ctx, request.ID)
+	storedDefinition, err := s.storage.GetDefinition(ctx, request.ID)
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsgf(err, "error getting presentation definition: %s", request.ID)
 	}
-	if storedPresentation == nil {
+	if storedDefinition == nil {
 		return nil, sdkutil.LoggingNewErrorf("presentation definition with id<%s> could not be found", request.ID)
 	}
-	// TODO(gabe) decouple this to a separate endpoint for presentation requests https://github.com/TBD54566975/ssi-service/issues/375
-	defJWT, err := s.keystore.Sign(ctx, storedPresentation.AuthorKID,
-		exchange.PresentationDefinitionEnvelope{PresentationDefinition: storedPresentation.PresentationDefinition})
-	if err != nil {
-		return nil, sdkutil.LoggingErrorMsgf(err, "signing presentation definition envelope by issuer<%s>", storedPresentation.Author)
-	}
 	return &model.GetPresentationDefinitionResponse{
-		ID:                        storedPresentation.ID,
-		PresentationDefinition:    storedPresentation.PresentationDefinition,
-		PresentationDefinitionJWT: *defJWT,
+		PresentationDefinition: storedDefinition.PresentationDefinition,
 	}, nil
 }
 
 func (s Service) DeletePresentationDefinition(ctx context.Context, request model.DeletePresentationDefinitionRequest) error {
 	logrus.Debugf("deleting presentation definition: %s", request.ID)
 
-	if err := s.storage.DeletePresentation(ctx, request.ID); err != nil {
+	if err := s.storage.DeleteDefinition(ctx, request.ID); err != nil {
 		return sdkutil.LoggingNewErrorf("could not delete presentation definition with id: %s", request.ID)
 	}
 
@@ -191,7 +178,7 @@ func (s Service) CreateSubmission(ctx context.Context, request model.CreateSubmi
 		return nil, errors.Errorf("submission with id %s already present", request.Submission.ID)
 	}
 
-	definition, err := s.storage.GetPresentation(ctx, request.Submission.DefinitionID)
+	storedDefinition, err := s.storage.GetDefinition(ctx, request.Submission.DefinitionID)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting presentation definition")
 	}
@@ -214,7 +201,7 @@ func (s Service) CreateSubmission(ctx context.Context, request model.CreateSubmi
 	}
 
 	// TODO(gabe) plug in additional credential verification logic here
-	if _, err = exchange.VerifyPresentationSubmissionVP(definition.PresentationDefinition, request.Presentation); err != nil {
+	if _, err = exchange.VerifyPresentationSubmissionVP(storedDefinition.PresentationDefinition, request.Presentation); err != nil {
 		return nil, errors.Wrap(err, "verifying presentation submission vp")
 	}
 
@@ -307,4 +294,89 @@ func (s Service) ListDefinitions(ctx context.Context) (*model.ListDefinitionsRes
 	}
 
 	return resp, nil
+}
+
+func (s Service) CreateRequest(ctx context.Context, req model.CreateRequestRequest) (*model.Request, error) {
+	if err := sdkutil.IsValidStruct(req); err != nil {
+		return nil, err
+	}
+
+	request := req.PresentationRequest
+	pd, err := s.storage.GetDefinition(ctx, request.PresentationDefinitionID)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting presentation definition")
+	}
+	if pd == nil {
+		return nil, errors.Errorf("presentation definition %q is nil", request.PresentationDefinitionID)
+	}
+
+	requestID := uuid.NewString()
+	token, err := jwt.NewBuilder().Claim("presentation_definition", pd.PresentationDefinition).
+		Audience(request.Audience).
+		Expiration(request.Expiration).
+		Issuer(request.IssuerDID).
+		NotBefore(time.Now()).
+		JwtID(requestID).
+		Build()
+	if err != nil {
+		return nil, errors.Wrap(err, "building jwt")
+	}
+	signedToken, err := s.keystore.Sign(ctx, request.KID, token)
+	if err != nil {
+		return nil, errors.Wrapf(err, "signing payload with KID %q", request.KID)
+	}
+
+	stored := presentationstorage.StoredRequest{
+		ID:                        requestID,
+		Audience:                  request.Audience,
+		Expiration:                request.Expiration.Format(time.RFC3339),
+		IssuerDID:                 request.IssuerDID,
+		KID:                       request.KID,
+		PresentationDefinitionID:  request.PresentationDefinitionID,
+		PresentationDefinitionJWT: signedToken.String(),
+	}
+	if err := s.storage.StoreRequest(ctx, stored); err != nil {
+		return nil, errors.Wrap(err, "storing signed document")
+	}
+	return serviceModel(&stored)
+}
+
+func (s Service) GetRequest(ctx context.Context, request *model.GetRequestRequest) (*model.Request, error) {
+	logrus.Debugf("getting presentation definition: %s", request.ID)
+
+	storedRequest, err := s.storage.GetRequest(ctx, request.ID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting signed document with id: %s", request.ID)
+	}
+	if storedRequest == nil {
+		return nil, sdkutil.LoggingNewErrorf("presentation request with id<%s> could not be found", request.ID)
+	}
+
+	return serviceModel(storedRequest)
+}
+
+func (s Service) DeleteRequest(ctx context.Context, request model.DeleteRequestRequest) error {
+	logrus.Debugf("deleting presentation request: %s", request.ID)
+
+	if err := s.storage.DeleteRequest(ctx, request.ID); err != nil {
+		return sdkutil.LoggingNewErrorf("could not delete presentation request with id: %s", request.ID)
+	}
+
+	return nil
+}
+
+func serviceModel(storedRequest *presentationstorage.StoredRequest) (*model.Request, error) {
+	expiration, err := time.Parse(time.RFC3339, storedRequest.Expiration)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing expiration time")
+	}
+	return &model.Request{
+		ID:                        storedRequest.ID,
+		Audience:                  storedRequest.Audience,
+		Expiration:                expiration,
+		IssuerDID:                 storedRequest.IssuerDID,
+		KID:                       storedRequest.KID,
+		PresentationDefinitionID:  storedRequest.PresentationDefinitionID,
+		PresentationDefinitionJWT: keyaccess.JWT(storedRequest.PresentationDefinitionJWT),
+	}, nil
 }

--- a/pkg/service/presentation/storage.go
+++ b/pkg/service/presentation/storage.go
@@ -20,17 +20,49 @@ import (
 
 const (
 	presentationDefinitionNamespace = "presentation_definition"
+	presentationRequestNamespace    = "presentation_request"
 )
-
-type StoredPresentation struct {
-	ID                     string                          `json:"id"`
-	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition"`
-	Author                 string                          `json:"issuerID"`
-	AuthorKID              string                          `json:"issuerKid"`
-}
 
 type Storage struct {
 	db storage.ServiceStorage
+}
+
+func (ps *Storage) StoreRequest(ctx context.Context, request prestorage.StoredRequest) error {
+	id := request.ID
+	if id == "" {
+		err := errors.New("could not store presentation request without an ID")
+		logrus.WithError(err).Error()
+		return err
+	}
+	jsonBytes, err := json.Marshal(request)
+	if err != nil {
+		errMsg := fmt.Sprintf("could not store presentation request: %s", id)
+		logrus.WithError(err).Error(errMsg)
+		return errors.Wrapf(err, errMsg)
+	}
+	return ps.db.Write(ctx, presentationRequestNamespace, id, jsonBytes)
+}
+
+func (ps *Storage) GetRequest(ctx context.Context, id string) (*prestorage.StoredRequest, error) {
+	jsonBytes, err := ps.db.Read(ctx, presentationRequestNamespace, id)
+	if err != nil {
+		return nil, sdkutil.LoggingErrorMsgf(err, "could not get presentation request: %s", id)
+	}
+	if len(jsonBytes) == 0 {
+		return nil, sdkutil.LoggingNewErrorf("presentation request not found with id: %s", id)
+	}
+	var stored prestorage.StoredRequest
+	if err := json.Unmarshal(jsonBytes, &stored); err != nil {
+		return nil, sdkutil.LoggingErrorMsgf(err, "could not unmarshal stored presentation definition: %s", id)
+	}
+	return &stored, nil
+}
+
+func (ps *Storage) DeleteRequest(ctx context.Context, id string) error {
+	if err := ps.db.Delete(ctx, presentationRequestNamespace, id); err != nil {
+		return sdkutil.LoggingNewErrorf("could not delete presentation request: %s", id)
+	}
+	return nil
 }
 
 func (ps *Storage) UpdateSubmission(ctx context.Context, id string, approved bool, reason string, opID string) (prestorage.StoredSubmission, opstorage.StoredOperation, error) {
@@ -97,14 +129,14 @@ func (ps *Storage) ListSubmissions(ctx context.Context, filter filtering.Filter)
 	return storedSubmissions, nil
 }
 
-func NewPresentationStorage(db storage.ServiceStorage) (*Storage, error) {
+func NewPresentationStorage(db storage.ServiceStorage) (prestorage.Storage, error) {
 	if db == nil {
 		return nil, errors.New("bolt db reference is nil")
 	}
 	return &Storage{db: db}, nil
 }
 
-func (ps *Storage) StorePresentation(ctx context.Context, presentation StoredPresentation) error {
+func (ps *Storage) StoreDefinition(ctx context.Context, presentation prestorage.StoredDefinition) error {
 	id := presentation.ID
 	if id == "" {
 		err := errors.New("could not store presentation definition without an ID")
@@ -120,7 +152,7 @@ func (ps *Storage) StorePresentation(ctx context.Context, presentation StoredPre
 	return ps.db.Write(ctx, presentationDefinitionNamespace, id, jsonBytes)
 }
 
-func (ps *Storage) GetPresentation(ctx context.Context, id string) (*StoredPresentation, error) {
+func (ps *Storage) GetDefinition(ctx context.Context, id string) (*prestorage.StoredDefinition, error) {
 	jsonBytes, err := ps.db.Read(ctx, presentationDefinitionNamespace, id)
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsgf(err, "could not get presentation definition: %s", id)
@@ -128,14 +160,14 @@ func (ps *Storage) GetPresentation(ctx context.Context, id string) (*StoredPrese
 	if len(jsonBytes) == 0 {
 		return nil, sdkutil.LoggingNewErrorf("presentation definition not found with id: %s", id)
 	}
-	var stored StoredPresentation
+	var stored prestorage.StoredDefinition
 	if err := json.Unmarshal(jsonBytes, &stored); err != nil {
 		return nil, sdkutil.LoggingErrorMsgf(err, "could not unmarshal stored presentation definition: %s", id)
 	}
 	return &stored, nil
 }
 
-func (ps *Storage) DeletePresentation(ctx context.Context, id string) error {
+func (ps *Storage) DeleteDefinition(ctx context.Context, id string) error {
 	if err := ps.db.Delete(ctx, presentationDefinitionNamespace, id); err != nil {
 		return sdkutil.LoggingNewErrorf("could not delete presentation definition: %s", id)
 	}

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/pkg/errors"
@@ -12,17 +14,21 @@ import (
 type StoredDefinition struct {
 	ID                     string                          `json:"id"`
 	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition"`
+	Author                 string                          `json:"issuerID"`
+	AuthorKID              string                          `json:"issuerKid"`
 }
 
 type Storage interface {
 	DefinitionStorage
+	RequestStorage
 	SubmissionStorage
 }
 
 type DefinitionStorage interface {
-	StoreDefinition(schema StoredDefinition) error
-	GetDefinition(id string) (*StoredDefinition, error)
-	DeleteDefinition(id string) error
+	StoreDefinition(ctx context.Context, presentation StoredDefinition) error
+	GetDefinition(ctx context.Context, id string) (*StoredDefinition, error)
+	DeleteDefinition(ctx context.Context, id string) error
+	ListDefinitions(ctx context.Context) ([]StoredDefinition, error)
 }
 
 type StoredSubmission struct {
@@ -38,10 +44,26 @@ func (s StoredSubmission) FilterVariablesMap() map[string]any {
 }
 
 type SubmissionStorage interface {
-	StoreSubmission(schema StoredSubmission) error
-	GetSubmission(id string) (*StoredSubmission, error)
-	ListSubmissions(filtering.Filter) ([]StoredSubmission, error)
-	UpdateSubmission(id string, approved bool, reason string, submissionID string) (StoredSubmission, opstorage.StoredOperation, error)
+	StoreSubmission(ctx context.Context, schema StoredSubmission) error
+	GetSubmission(ctx context.Context, id string) (*StoredSubmission, error)
+	ListSubmissions(ctx context.Context, filter filtering.Filter) ([]StoredSubmission, error)
+	UpdateSubmission(ctx context.Context, id string, approved bool, reason string, submissionID string) (StoredSubmission, opstorage.StoredOperation, error)
 }
 
 var ErrSubmissionNotFound = errors.New("submission not found")
+
+type StoredRequest struct {
+	ID                        string   `json:"id"`
+	Audience                  []string `json:"audience"`
+	Expiration                string   `json:"expiration"`
+	IssuerDID                 string   `json:"issuerID"`
+	KID                       string   `json:"kid"`
+	PresentationDefinitionID  string   `json:"presentationDefinitionId"`
+	PresentationDefinitionJWT string   `json:"presentationRequestJwt"`
+}
+
+type RequestStorage interface {
+	StoreRequest(context.Context, StoredRequest) error
+	GetRequest(context.Context, string) (*StoredRequest, error)
+	DeleteRequest(context.Context, string) error
+}


### PR DESCRIPTION
# Overview
This addresses #375 by creating a separate endpoint for it.

# Description
This follows the same pattern as definitions/submissions in the `presentation` package.

# How Has This Been Tested?
Unit tests.

