### PR TITLE
expose storage object in instantiateServices for later use

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -30,6 +30,7 @@ type SSIService struct {
 	Presentation *presentation.Service
 	Operation    *operation.Service
 	Webhook      *webhook.Service
+	storage      storage.ServiceStorage
 }
 
 // InstantiateSSIService creates a new instance of the SSIS which instantiates all services and their
@@ -139,6 +140,7 @@ func instantiateServices(config config.ServicesConfig) (*SSIService, error) {
 		Presentation: presentationService,
 		Operation:    operationService,
 		Webhook:      webhookService,
+		storage:      storageProvider,
 	}, nil
 }
 
@@ -155,4 +157,8 @@ func (s *SSIService) GetServices() []framework.Service {
 		s.Operation,
 		s.Webhook,
 	}
+}
+
+func (service *SSIService) GetStorage() storage.ServiceStorage {
+	return service.storage
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -159,6 +159,6 @@ func (s *SSIService) GetServices() []framework.Service {
 	}
 }
 
-func (service *SSIService) GetStorage() storage.ServiceStorage {
-	return service.storage
+func (s *SSIService) GetStorage() storage.ServiceStorage {
+	return s.storage
 }


### PR DESCRIPTION
# Overview

This allows the storage object to be reachable from outside the instantiateServices's function. There are good reasons to do this. It allows the storage provider to be reused on services that might extend the ssi service,  which is a reasonable use case IMO (we are doing it at Benri). Bolt, in particular, is finicky with how it interacts with storage objects. If you concurrently open two bolt providers for the same file on the same service, it seems the first open locks the second ( at least in my experience ), so reusing the storage provider for other functions requires this to be exposed.

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages

