### PR TITLE
show an example of gin middleware for authorization and authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Note that at this time, we do not currently support rotating the master key.
 - If does not exist...it uses a default config defined in the code inline
 3. Finally, it loads the config/.env file and adds the env variables defined in this file to the final SSIServiceConfig
 
+### Authentication and Authorization
+
+The ssi server uses the Gin framework from Golang, which allows various kinds of middleware. Look in `pkg/middleware/Authentication.go` and `pkg/middleware/Authorization.go` for details on how you can wire up authentication and authorization for your use case.
+
 ## Pre-built images to use
 
 There are pre-build images built by github actions on each merge to the main branch, which you can access here:

--- a/pkg/server/middleware/Authentication.go
+++ b/pkg/server/middleware/Authentication.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		// This is a dummy check here. You should do your actual JWT token verification.
+		if token == "" {
+			/*
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization is required"})
+				c.Abort()
+				return
+			*/
+		}
+		// Assuming that the token is valid and we got the user info from the JWT token.
+		// You should replace it with actual user info.
+		user := "user"
+		c.Set("user", user)
+		c.Next()
+	}
+}

--- a/pkg/server/middleware/Authentication.go
+++ b/pkg/server/middleware/Authentication.go
@@ -6,6 +6,23 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+/*
+To use this middleware, you need to add it to your gin router in server.go:
+
+// setUpEngine creates the gin engine and sets up the middleware based on config
+func setUpEngine(cfg config.ServerConfig, shutdown chan os.Signal) *gin.Engine {
+	gin.ForceConsoleColor()
+	middlewares := gin.HandlersChain{
+		gin.Recovery(),
+		gin.Logger(),
+		middleware.Errors(shutdown),
+		middleware.AuthMiddleware(),
+		middleware.AuthorizationMiddleware(),
+	}
+
+
+*/
+
 func AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := c.GetHeader("Authorization")

--- a/pkg/server/middleware/Authentication.go
+++ b/pkg/server/middleware/Authentication.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -8,12 +10,10 @@ func AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := c.GetHeader("Authorization")
 		// This is a dummy check here. You should do your actual JWT token verification.
-		if token == "" {
-			/*
-				c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization is required"})
-				c.Abort()
-				return
-			*/
+		if token == "IF YOU SET IT TO THIS VALUE IT WILL FAIL" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization is required"})
+			c.Abort()
+			return
 		}
 		// Assuming that the token is valid and we got the user info from the JWT token.
 		// You should replace it with actual user info.

--- a/pkg/server/middleware/Authorization.go
+++ b/pkg/server/middleware/Authorization.go
@@ -4,6 +4,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+/*
+To use this middleware, you need to add it to your gin router in server.go:
+
+// setUpEngine creates the gin engine and sets up the middleware based on config
+func setUpEngine(cfg config.ServerConfig, shutdown chan os.Signal) *gin.Engine {
+	gin.ForceConsoleColor()
+	middlewares := gin.HandlersChain{
+		gin.Recovery(),
+		gin.Logger(),
+		middleware.Errors(shutdown),
+		middleware.AuthMiddleware(),
+	}
+
+*/
+
 func AuthorizationMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userRole := "userRole" // Retrieve user role from the JWT or context

--- a/pkg/server/middleware/Authorization.go
+++ b/pkg/server/middleware/Authorization.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func AuthorizationMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userRole := "userRole" // Retrieve user role from the JWT or context
+		path := c.FullPath()
+
+		switch {
+
+		case userRole == "admin":
+			// Admin has access to every endpoint
+			c.Next()
+
+		case userRole == "user" && path != "/admin-endpoint":
+			// Users do not have access to the admin endpoint
+			c.Next()
+
+		default:
+			//c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+			//c.Abort()
+			//return
+			c.Next()
+		}
+	}
+}

--- a/pkg/server/middleware/Authorization.go
+++ b/pkg/server/middleware/Authorization.go
@@ -20,10 +20,10 @@ func AuthorizationMiddleware() gin.HandlerFunc {
 			c.Next()
 
 		default:
-			//Normally you would return a 403 here, but for the sake of the example we will just call next
-			//c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
-			//c.Abort()
-			//return
+			// Normally you would return a 403 here, but for the sake of the example we will just call next
+			// c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
+			// c.Abort()
+			// return
 			c.Next()
 		}
 	}

--- a/pkg/server/middleware/Authorization.go
+++ b/pkg/server/middleware/Authorization.go
@@ -20,6 +20,7 @@ func AuthorizationMiddleware() gin.HandlerFunc {
 			c.Next()
 
 		default:
+			//Normally you would return a 403 here, but for the sake of the example we will just call next
 			//c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
 			//c.Abort()
 			//return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,6 +166,8 @@ func setUpEngine(cfg config.ServerConfig, shutdown chan os.Signal) *gin.Engine {
 		gin.Recovery(),
 		gin.Logger(),
 		middleware.Errors(shutdown),
+		middleware.AuthMiddleware(),          // Add this line
+		middleware.AuthorizationMiddleware(), // Add this line
 	}
 	if cfg.JagerEnabled {
 		middlewares = append(middlewares, otelgin.Middleware(config.ServiceName))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,8 +166,6 @@ func setUpEngine(cfg config.ServerConfig, shutdown chan os.Signal) *gin.Engine {
 		gin.Recovery(),
 		gin.Logger(),
 		middleware.Errors(shutdown),
-		middleware.AuthMiddleware(),
-		middleware.AuthorizationMiddleware(),
 	}
 	if cfg.JagerEnabled {
 		middlewares = append(middlewares, otelgin.Middleware(config.ServiceName))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,8 +166,8 @@ func setUpEngine(cfg config.ServerConfig, shutdown chan os.Signal) *gin.Engine {
 		gin.Recovery(),
 		gin.Logger(),
 		middleware.Errors(shutdown),
-		middleware.AuthMiddleware(),          // Add this line
-		middleware.AuthorizationMiddleware(), // Add this line
+		middleware.AuthMiddleware(),
+		middleware.AuthorizationMiddleware(),
 	}
 	if cfg.JagerEnabled {
 		middlewares = append(middlewares, otelgin.Middleware(config.ServiceName))


### PR DESCRIPTION
# Overview
Implementers of an ssi-service may want to weave in authentication and authorization.

# Description
This shows how it can be done with stubbed out code which can be modified as needed. 
There isn't an easy runtime plugin mechanism for golang so this would likely be done by the implementer.

# How Has This Been Tested?

Regression tests covers this as it adds no functionality.



## References
https://github.com/gin-gonic/gin/blob/master/docs/doc.md#using-basicauth-middleware 