### PR TITLE
Uptake latest SDK; fix empty Credential JWT fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230601154259-07707db2c404
+	github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230623174120-9617360e9ee2
 	github.com/alicebob/miniredis/v2 v2.30.3
 	github.com/ardanlabs/conf v1.5.0
 	github.com/benbjohnson/clock v1.3.5
@@ -58,7 +58,7 @@ require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go v1.44.277 // indirect
-	github.com/bits-and-blooms/bitset v1.7.0 // indirect
+	github.com/bits-and-blooms/bitset v1.8.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -130,7 +130,7 @@ require (
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
-	github.com/multiformats/go-multihash v0.2.2 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/ory/go-acc v0.2.9-0.20230103102148-6b1c9a70dbbe // indirect
 	github.com/ory/go-convenience v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
-github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230601154259-07707db2c404 h1:EwiJaa6rT7HciSJSK1cDhXbwW8jVln0nwm5X+6s0Lxs=
-github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230601154259-07707db2c404/go.mod h1:Lbdhy8ASuiEuRRk/bKbNcwa5VOrejk/CXo+6HESlwxo=
+github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230623174120-9617360e9ee2 h1:cJLc4zt1GpOXxQ5hzP+Z0j7GXSx/xyq7DW0jjapzSbE=
+github.com/TBD54566975/ssi-sdk v0.0.4-alpha.0.20230623174120-9617360e9ee2/go.mod h1:yPkVO9MCC/kRu+lut3jllhnCV0gEqSubaaSVT7xLSOs=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
@@ -64,8 +64,8 @@ github.com/aws/aws-sdk-go v1.44.277 h1:YHmyzBPARTJ7LLYV1fxbfEbQOaUh3kh52hb7nBvX3
 github.com/aws/aws-sdk-go v1.44.277/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHlV4j7NEo=
-github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
+github.com/bits-and-blooms/bitset v1.8.0 h1:FD+XqgOZDUxxZ8hzoBFuV9+cGWY9CslN6d5MS5JVb4c=
+github.com/bits-and-blooms/bitset v1.8.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
@@ -385,8 +385,8 @@ github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivnc
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=
 github.com/multiformats/go-multicodec v0.9.0 h1:pb/dlPnzee/Sxv/j4PmkDRxCOi3hXTz3IbPKOXWJkmg=
 github.com/multiformats/go-multicodec v0.9.0/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
-github.com/multiformats/go-multihash v0.2.2 h1:Uu7LWs/PmWby1gkj1S1DXx3zyd3aVabA4FiMKn/2tAc=
-github.com/multiformats/go-multihash v0.2.2/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
+github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7BFvVU9RSh+U=
+github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=

--- a/integration/credential_manifest_integration_test.go
+++ b/integration/credential_manifest_integration_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"testing"
 
-	credsdk "github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/did/key"
 	"github.com/stretchr/testify/assert"
@@ -370,7 +370,7 @@ func TestSubmitAndReviewApplicationIntegration(t *testing.T) {
 	vc, err := getJSONElement(reviewApplicationOutput, "$.verifiableCredentials[0]")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vc)
-	_, _, typedVC, err := credsdk.ToCredential(vc)
+	_, _, typedVC, err := parsing.ToCredential(vc)
 	assert.NoError(t, err)
 	assert.Equal(t, "Mister", typedVC.CredentialSubject["givenName"])
 	assert.Equal(t, "Tee", typedVC.CredentialSubject["familyName"])

--- a/internal/credential/model.go
+++ b/internal/credential/model.go
@@ -5,8 +5,10 @@ import (
 	"reflect"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
+
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 )
 
@@ -57,7 +59,7 @@ func (c Container) HasJWTCredential() bool {
 
 // NewCredentialContainerFromJWT attempts to parse a VC-JWT credential from a string into a Container
 func NewCredentialContainerFromJWT(credentialJWT string) (*Container, error) {
-	_, _, cred, err := credential.ToCredential(credentialJWT)
+	_, _, cred, err := parsing.ToCredential(credentialJWT)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse credential from JWT")
 	}
@@ -70,7 +72,7 @@ func NewCredentialContainerFromJWT(credentialJWT string) (*Container, error) {
 // NewCredentialContainerFromMap attempts to parse a data integrity credential from a piece of JSON,
 // which is represented as a map in go, into a Container
 func NewCredentialContainerFromMap(credMap map[string]any) (*Container, error) {
-	_, _, cred, err := credential.ToCredential(credMap)
+	_, _, cred, err := parsing.ToCredential(credMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse credential from map")
 	}

--- a/internal/keyaccess/jwt.go
+++ b/internal/keyaccess/jwt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/integrity"
 	"github.com/TBD54566975/ssi-sdk/crypto/jwx"
 	"github.com/TBD54566975/ssi-sdk/did/resolution"
 	"github.com/goccy/go-json"
@@ -122,7 +123,7 @@ func (ka JWKKeyAccess) SignVerifiableCredential(cred credential.VerifiableCreden
 		return nil, errors.New("cannot sign invalid credential")
 	}
 
-	tokenBytes, err := credential.SignVerifiableCredentialJWT(*ka.Signer, cred)
+	tokenBytes, err := integrity.SignVerifiableCredentialJWT(*ka.Signer, cred)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not sign cred")
 	}
@@ -133,7 +134,7 @@ func (ka JWKKeyAccess) VerifyVerifiableCredential(token JWT) (*credential.Verifi
 	if token == "" {
 		return nil, errors.New("token cannot be empty")
 	}
-	_, _, verifiableCredential, err := credential.VerifyVerifiableCredentialJWT(*ka.Verifier, token.String())
+	_, _, verifiableCredential, err := integrity.VerifyVerifiableCredentialJWT(*ka.Verifier, token.String())
 	return verifiableCredential, err
 }
 
@@ -144,7 +145,7 @@ func (ka JWKKeyAccess) SignVerifiablePresentation(audience string, presentation 
 	if err := presentation.IsValid(); err != nil {
 		return nil, errors.New("cannot sign invalid presentation")
 	}
-	tokenBytes, err := credential.SignVerifiablePresentationJWT(*ka.Signer, credential.JWTVVPParameters{Audience: []string{audience}}, presentation)
+	tokenBytes, err := integrity.SignVerifiablePresentationJWT(*ka.Signer, integrity.JWTVVPParameters{Audience: []string{audience}}, presentation)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not sign presentation")
 	}
@@ -155,7 +156,7 @@ func (ka JWKKeyAccess) VerifyVerifiablePresentation(ctx context.Context, resolve
 	if token == "" {
 		return nil, errors.New("token cannot be empty")
 	}
-	_, _, presentation, err := credential.VerifyVerifiablePresentationJWT(ctx, *ka.Verifier, resolver, token.String())
+	_, _, presentation, err := integrity.VerifyVerifiablePresentationJWT(ctx, *ka.Verifier, resolver, token.String())
 	return presentation, err
 }
 

--- a/pkg/server/router/presentation.go
+++ b/pkg/server/router/presentation.go
@@ -5,13 +5,14 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	"github.com/TBD54566975/ssi-sdk/credential/integrity"
 	"github.com/gin-gonic/gin"
 	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
-	"github.com/tbd54566975/ssi-service/pkg/server/pagination"
 	"go.einride.tech/aip/filtering"
+
+	"github.com/tbd54566975/ssi-service/pkg/server/pagination"
 
 	credint "github.com/tbd54566975/ssi-service/internal/credential"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
@@ -227,7 +228,7 @@ type CreateSubmissionRequest struct {
 }
 
 func (r CreateSubmissionRequest) toServiceRequest() (*model.CreateSubmissionRequest, error) {
-	_, _, vp, err := credential.ParseVerifiablePresentationFromJWT(r.SubmissionJWT.String())
+	_, _, vp, err := integrity.ParseVerifiablePresentationFromJWT(r.SubmissionJWT.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing presentation from jwt")
 	}

--- a/pkg/server/server_manifest_test.go
+++ b/pkg/server/server_manifest_test.go
@@ -10,6 +10,7 @@ import (
 
 	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/manifest"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
 	"github.com/TBD54566975/ssi-sdk/did/key"
@@ -450,7 +451,7 @@ func TestManifestAPI(t *testing.T) {
 				assert.NoError(tt, err)
 				assert.Len(tt, appResp.Credentials, 2, "each output_descriptor in the definition should result in a credential")
 
-				_, _, vc, err := credsdk.ToCredential(appResp.Credentials[0])
+				_, _, vc, err := parsing.ToCredential(appResp.Credentials[0])
 				assert.NoError(tt, err)
 				expectedSubject := credsdk.CredentialSubject{
 					"id":        applicantDID.ID,
@@ -463,7 +464,7 @@ func TestManifestAPI(t *testing.T) {
 				assert.Equal(tt, licenseSchema.ID, vc.CredentialSchema.ID)
 				assert.Empty(tt, vc.CredentialStatus)
 
-				_, _, vc2, err := credsdk.ToCredential(appResp.Credentials[1])
+				_, _, vc2, err := parsing.ToCredential(appResp.Credentials[1])
 				assert.NoError(tt, err)
 				expectedSubject = credsdk.CredentialSubject{
 					"id":        applicantDID.ID,
@@ -638,7 +639,7 @@ func TestManifestAPI(t *testing.T) {
 				assert.Len(tt, appResp.Credentials, 2)
 				assert.Empty(tt, appResp.Response.Denial)
 
-				_, _, vc, err := credsdk.ToCredential(appResp.Credentials[0])
+				_, _, vc, err := parsing.ToCredential(appResp.Credentials[0])
 				assert.NoError(tt, err)
 				assert.Equal(tt, credsdk.CredentialSubject{
 					"id":        applicantDID.ID,

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	"github.com/TBD54566975/ssi-sdk/credential/integrity"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/crypto/jwx"
 	didsdk "github.com/TBD54566975/ssi-sdk/did"
@@ -21,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tbd54566975/ssi-service/pkg/testutil"
 
 	"github.com/tbd54566975/ssi-service/config"
@@ -768,7 +770,7 @@ func createSubmissionRequest(t *testing.T, definitionID, requesterDID string, vc
 	holderSigner jwx.Signer, holderDID key.DIDKey) router.CreateSubmissionRequest {
 	issuerSigner, didKey := getSigner(t)
 	vc.Issuer = didKey.String()
-	vcData, err := credential.SignVerifiableCredentialJWT(issuerSigner, vc)
+	vcData, err := integrity.SignVerifiableCredentialJWT(issuerSigner, vc)
 	require.NoError(t, err)
 	ps := exchange.PresentationSubmission{
 		ID:           uuid.NewString(),
@@ -791,7 +793,7 @@ func createSubmissionRequest(t *testing.T, definitionID, requesterDID string, vc
 		VerifiableCredential:   []any{keyaccess.JWT(vcData)},
 	}
 
-	signed, err := credential.SignVerifiablePresentationJWT(holderSigner, credential.JWTVVPParameters{Audience: []string{requesterDID}}, vp)
+	signed, err := integrity.SignVerifiablePresentationJWT(holderSigner, integrity.JWTVVPParameters{Audience: []string{requesterDID}}, vp)
 	require.NoError(t, err)
 
 	request := router.CreateSubmissionRequest{SubmissionJWT: keyaccess.JWT(signed)}

--- a/pkg/server/server_schema_test.go
+++ b/pkg/server/server_schema_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	"github.com/TBD54566975/ssi-sdk/credential/schema"
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/goccy/go-json"
@@ -127,7 +127,7 @@ func TestSchemaAPI(t *testing.T) {
 				assert.Equal(tt, schema.CredentialSchema2023Type, resp.Type)
 
 				// decode the schema from the response and verify it
-				_, _, cred, err := credential.ToCredential(resp.CredentialSchema.String())
+				_, _, cred, err := parsing.ToCredential(resp.CredentialSchema.String())
 				assert.NoError(tt, err)
 				credSubjectBytes, err := json.Marshal(cred.CredentialSubject)
 				assert.NoError(tt, err)

--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/tbd54566975/ssi-service/config"
 	credint "github.com/tbd54566975/ssi-service/internal/credential"
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
@@ -26,7 +27,7 @@ import (
 type Service struct {
 	storage  *Storage
 	config   config.CredentialServiceConfig
-	verifier *credint.Verifier
+	verifier *credint.Validator
 
 	// external dependencies
 	keyStore *keystore.Service
@@ -69,7 +70,7 @@ func NewCredentialService(config config.CredentialServiceConfig, s storage.Servi
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate storage for the credential service")
 	}
-	verifier, err := credint.NewCredentialVerifier(didResolver, schema)
+	verifier, err := credint.NewCredentialValidator(didResolver, schema)
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate verifier for the credential service")
 	}

--- a/pkg/service/credential/storage.go
+++ b/pkg/service/credential/storage.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/integrity"
 	statussdk "github.com/TBD54566975/ssi-sdk/credential/status"
 	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/goccy/go-json"
@@ -283,7 +284,7 @@ func buildStoredCredential(request StoreCredentialRequest) (*StoredCredential, e
 	// assume we have a Data Integrity credential
 	cred := request.Credential
 	if request.HasJWTCredential() {
-		_, _, parsedCred, err := credential.ParseVerifiableCredentialFromJWT(request.CredentialJWT.String())
+		_, _, parsedCred, err := integrity.ParseVerifiableCredentialFromJWT(request.CredentialJWT.String())
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse credential from jwt")
 		}

--- a/pkg/service/manifest/response.go
+++ b/pkg/service/manifest/response.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	"github.com/TBD54566975/ssi-sdk/credential/manifest"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	errresp "github.com/TBD54566975/ssi-sdk/error"
 	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/goccy/go-json"
@@ -238,7 +238,7 @@ func getCredentialForInputDescriptor(applicationJSON map[string]any, templateInp
 }
 
 func toCredentialJSON(c any) (map[string]any, error) {
-	_, _, genericCredential, err := credsdk.ToCredential(c)
+	_, _, genericCredential, err := parsing.ToCredential(c)
 	if err != nil {
 		return nil, errors.Wrapf(err, "converting credential to json")
 	}

--- a/pkg/service/presentation/service.go
+++ b/pkg/service/presentation/service.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	credsdk "github.com/TBD54566975/ssi-sdk/credential"
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	"github.com/TBD54566975/ssi-sdk/credential/integrity"
 	"github.com/TBD54566975/ssi-sdk/did/resolution"
 	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/internal/credential"
 	didint "github.com/tbd54566975/ssi-service/internal/did"
@@ -36,7 +37,7 @@ type Service struct {
 	config     config.PresentationServiceConfig
 	resolver   resolution.Resolver
 	schema     *schema.Service
-	verifier   *credential.Verifier
+	verifier   *credential.Validator
 	reqStorage common.RequestStorage
 }
 
@@ -72,7 +73,7 @@ func NewPresentationService(config config.PresentationServiceConfig, s storage.S
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate storage for the operations")
 	}
-	verifier, err := credential.NewCredentialVerifier(resolver, schema)
+	verifier, err := credential.NewCredentialValidator(resolver, schema)
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate verifier")
 	}
@@ -175,7 +176,7 @@ func (s Service) CreateSubmission(ctx context.Context, request model.CreateSubmi
 		return nil, errors.Wrap(err, "provided value is not a valid presentation submission")
 	}
 
-	headers, _, vp, err := credsdk.ParseVerifiablePresentationFromJWT(request.SubmissionJWT.String())
+	headers, _, vp, err := integrity.ParseVerifiablePresentationFromJWT(request.SubmissionJWT.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing vp from jwt")
 	}

--- a/pkg/service/schema/service.go
+++ b/pkg/service/schema/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/parsing"
 	"github.com/TBD54566975/ssi-sdk/credential/schema"
 	"github.com/TBD54566975/ssi-sdk/did/resolution"
 	schemalib "github.com/TBD54566975/ssi-sdk/schema"
@@ -256,7 +257,7 @@ func (s Service) Resolve(ctx context.Context, id string) (*schema.JSONSchema, sc
 	case schema.JSONSchema2023Type:
 		return gotSchemaResponse.Schema, schema.JSONSchema2023Type, nil
 	case schema.CredentialSchema2023Type:
-		_, _, cred, err := credential.ToCredential(gotSchemaResponse.CredentialSchema.String())
+		_, _, cred, err := parsing.ToCredential(gotSchemaResponse.CredentialSchema.String())
 		if err != nil {
 			return nil, "", sdkutil.LoggingErrorMsg(err, "converting credential schema from jwt to credential map")
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -81,7 +81,7 @@ func NewStorage(storageProvider Type, opts ...Option) (ServiceStorage, error) {
 	if impl == nil {
 		return impl, fmt.Errorf("unsupported storage provider: %s", storageProvider)
 	}
-	logrus.Infof("STORAGE OPTS: %+v", opts)
+	logrus.Infof("Storage options: %+v", opts)
 	err := impl.Init(opts...)
 	return impl, err
 }


### PR DESCRIPTION
- uptake latest SDK, no functional changes
- Credentials had empty fields for mapped properties:

```json
{
  "iat": 1687808049,
  "iss": "did:key:z6MkqxtKEsULH8DaadP1HZegmVS2z91B7No4GzvrVHvpShXM",
  "jti": "http://localhost:3000/v1/credentials/691cd8ba-f7bb-4650-89bb-0e0ddee6caf8",
  "nbf": 1687808049,
  "nonce": "bc6b746a-3ab6-4709-96d5-f18a4962ba26",
  "sub": "did:key:z6MkqxtKEsULH8DaadP1HZegmVS2z91B7No4GzvrVHvpShXM",
  "vc": {
    "@context": [
      "https://www.w3.org/2018/credentials/v1"
    ],
    "type": [
      "VerifiableCredential"
    ],
    "issuer": "",
    "issuanceDate": "",
    "credentialSubject": {
      "firstName": "Test"
    }
  }
}
```

these properties are now removed