### PR TITLE
Only use a single encryption key across instances

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -230,6 +230,7 @@ func testKeyStoreService(t *testing.T, db storage.ServiceStorage) (*keystore.Ser
 	}
 
 	// create a keystore service
+	require.NoError(t, keystore.EnsureServiceKeyExists(serviceConfig, db))
 	factory := keystore.NewKeyStoreServiceFactory(serviceConfig, db)
 	keystoreService, err := factory(db)
 	require.NoError(t, err)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdkutil "github.com/TBD54566975/ssi-sdk/util"
-
 	"github.com/tbd54566975/ssi-service/config"
 	"github.com/tbd54566975/ssi-service/pkg/service/credential"
 	"github.com/tbd54566975/ssi-service/pkg/service/did"
@@ -90,7 +89,13 @@ func instantiateServices(config config.ServicesConfig) (*SSIService, error) {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate the webhook service")
 	}
 
+	if err := keystore.EnsureServiceKeyExists(config.KeyStoreConfig, storageProvider); err != nil {
+		return nil, sdkutil.LoggingErrorMsg(err, "could not ensure the service key exists")
+	}
 	keyStoreServiceFactory := keystore.NewKeyStoreServiceFactory(config.KeyStoreConfig, storageProvider)
+	if err != nil {
+		return nil, sdkutil.LoggingErrorMsg(err, "could not instantiate the keystore service factory")
+	}
 
 	keyStoreService, err := keyStoreServiceFactory(storageProvider)
 	if err != nil {


### PR DESCRIPTION
# Overview
Fixes #560, where multiple instances of the service used different encryption keys.

# Description
This is fixing the bug. 

# How Has This Been Tested?
I tested this by restarting the ssi-service docker container, and checking that the serviceKey didn't change. 
