### PR TITLE
Adding external credential integ test

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -407,7 +407,14 @@ func CreateSubmissionWithExternalCredential(params submissionParams) (string, er
 	logrus.Println("\n\nCreate our Submission with external credential:")
 
 	holderPrivateKey, holderDIDKey, err := key.GenerateDIDKey(crypto.Ed25519)
+	if err != nil {
+		return "", errors.Wrapf(err, "generating did key")
+	}
 	holderDID, err := holderDIDKey.Expand()
+	if err != nil {
+		return "", errors.Wrapf(err, "problem expanding did")
+	}
+
 	holderKID := holderDID.VerificationMethod[0].ID
 
 	params.HolderID = holderDID.ID

--- a/integration/testdata/presentation-submission-external-credential-input.json
+++ b/integration/testdata/presentation-submission-external-credential-input.json
@@ -1,0 +1,25 @@
+{
+  "vp": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1"
+    ],
+    "holder": "{{.HolderID}}",
+    "type": [
+      "VerifiablePresentation"
+    ],
+    "presentation_submission": {
+      "id": "{{.SubmissionID}}",
+      "definition_id": "{{.DefinitionID}}",
+      "descriptor_map": [
+        {
+          "id": "wa_driver_license",
+          "format": "jwt_vp",
+          "path": "$.verifiableCredential[0]"
+        }
+      ]
+    },
+    "verifiableCredential": [
+      "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa25uTnZOZFltcTg0REZNeHBSZDZDZ2l1VE5jcVltaWRQWjhYYlR6U3BtU3B1I3o2TWtubk52TmRZbXE4NERGTXhwUmQ2Q2dpdVROY3FZbWlkUFo4WGJUelNwbVNwdSIsInR5cCI6IkpXVCJ9.eyJleHAiOjI1ODAxMzAwODAsImlhdCI6MTY4NzgwNjAwNywiaXNzIjoiZGlkOmtleTp6Nk1rbm5Odk5kWW1xODRERk14cFJkNkNnaXVUTmNxWW1pZFBaOFhiVHpTcG1TcHUiLCJqdGkiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvdjEvY3JlZGVudGlhbHMvYWY5MmJjNTItOGQzYy00ZGYxLTgzNDctYmYwNDBjZDc1YWZkIiwibmJmIjoxNjg3ODA2MDA3LCJub25jZSI6IjUxY2JlMmEyLTc3NjAtNGU1OS1iYzU5LTFiNTY5ZWQwNjJjMSIsInN1YiI6ImRpZDprZXk6ejZNa3JqaXRCcERtOWVlaE44TmN3bWhFMkp4Q0p3UFlWVkpyaDJIQ1F0U3llakZGIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiIiLCJpc3N1YW5jZURhdGUiOiIiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJhZGRpdGlvbmFsTmFtZSI6Ik1jbG92aW4iLCJkYXRlT2ZCaXJ0aCI6IjE5ODctMDEtMDIiLCJmYW1pbHlOYW1lIjoiQW5kcmVzIiwiZ2l2ZW5OYW1lIjoiVXJpYmUifX19.nJpKHMMNSIA8AiCBje1qVHRJS2BEmoKzlQmRS6D9m7NVnyMBSvu3xpUvi2BaqO0sqiPl3O6P-yLuBIIuegFEAA"
+    ]
+  }
+}


### PR DESCRIPTION
# Overview
This integration test adds a case where the credential is external and the submission JWT is signed with a key created on the fly and not in the ssi-service database