### PR TITLE
Renamed IssuerKID to VerificationMethodID

### DIFF
--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -542,16 +542,19 @@ definitions:
           using JWS. In other words, the `proof` field is not present. See `credentialJwt` for the secured Verifiable
           Credential.
       credentialJwt:
-        description: JWT representation of `credential`, secured with an external
-          proof signed by `issuerKid`.
+        description: |-
+          JWT representation of `credential`, secured with an external proof. Verification can be done according to
+          `fullyQualifiedVerificationMethodId`.
+        type: string
+      fullyQualifiedVerificationMethodId:
+        description: |-
+          Fully qualified verification method ID that can be used to verify the credential. For example
+          `did:ion:EiDpQBo_nEfuLVeppgmPVQNEhtrnZLWFsB9ziZUuaKCJ3Q#83526c36-136c-423b-a57a-f190b83ae531`.
         type: string
       id:
         description: |-
           UUID assigned by the ssi-service. For example, 48958871-6a6d-4a25-889f-88c9c6835780. The `credential.id`
           value will be a URL that can be dereferenced, which includes this ID.
-        type: string
-      issuerKid:
-        description: The KID of the private key used to sign `credentialJwt`.
         type: string
       revoked:
         description: Whether this credential is currently revoked.
@@ -629,15 +632,19 @@ definitions:
         description: ID of this template.
         type: string
       issuer:
-        description: ID of the issuer that will be issuance the credentials.
+        description: ID of the issuer that will be issuing the credentials.
         type: string
-      issuerKid:
-        description: ID of the key that will be used to sign the credentials.
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the credentials.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
         type: string
     required:
     - credentialManifest
     - issuer
-    - issuerKid
+    - verificationMethodId
     type: object
   github_com_tbd54566975_ssi-service_pkg_service_issuance.TimeLike:
     properties:
@@ -686,16 +693,20 @@ definitions:
       issuerId:
         description: DID of the issuer of this presentation definition.
         type: string
-      issuerKid:
-        description: The privateKey associated with the KID used to sign the JWT.
-        type: string
       manifestId:
         description: ID of the credential manifest used for this request.
         type: string
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the JWT.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - issuerId
-    - issuerKid
     - manifestId
+    - verificationMethodId
     type: object
   github_com_tbd54566975_ssi-service_pkg_service_presentation_model.Request:
     properties:
@@ -715,9 +726,6 @@ definitions:
       issuerId:
         description: DID of the issuer of this presentation definition.
         type: string
-      issuerKid:
-        description: The privateKey associated with the KID used to sign the JWT.
-        type: string
       presentationDefinitionId:
         description: ID of the presentation definition used for this request.
         type: string
@@ -727,10 +735,17 @@ definitions:
           value of the field named "presentation_definition.id" matches PresentationDefinitionID.
           This is an output only field.
         type: string
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the JWT.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - issuerId
-    - issuerKid
     - presentationDefinitionId
+    - verificationMethodId
     type: object
   github_com_tbd54566975_ssi-service_pkg_service_presentation_model.Submission:
     properties:
@@ -1021,10 +1036,6 @@ definitions:
         description: The issuer id.
         example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
         type: string
-      issuerKid:
-        description: The KID used to sign the credential.
-        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
-        type: string
       revocable:
         description: |-
           Whether this credential can be revoked. When true, the created VC will have the "credentialStatus"
@@ -1046,11 +1057,18 @@ definitions:
           property set.
         example: false
         type: boolean
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the credential.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - data
     - issuer
-    - issuerKid
     - subject
+    - verificationMethodId
     type: object
   pkg_server_router.CreateCredentialResponse:
     properties:
@@ -1062,16 +1080,19 @@ definitions:
           using JWS. In other words, the `proof` field is not present. See `credentialJwt` for the secured Verifiable
           Credential.
       credentialJwt:
-        description: JWT representation of `credential`, secured with an external
-          proof signed by `issuerKid`.
+        description: |-
+          JWT representation of `credential`, secured with an external proof. Verification can be done according to
+          `fullyQualifiedVerificationMethodId`.
+        type: string
+      fullyQualifiedVerificationMethodId:
+        description: |-
+          Fully qualified verification method ID that can be used to verify the credential. For example
+          `did:ion:EiDpQBo_nEfuLVeppgmPVQNEhtrnZLWFsB9ziZUuaKCJ3Q#83526c36-136c-423b-a57a-f190b83ae531`.
         type: string
       id:
         description: |-
           UUID assigned by the ssi-service. For example, 48958871-6a6d-4a25-889f-88c9c6835780. The `credential.id`
           value will be a URL that can be dereferenced, which includes this ID.
-        type: string
-      issuerKid:
-        description: The KID of the private key used to sign `credentialJwt`.
         type: string
       revoked:
         description: Whether this credential is currently revoked.
@@ -1113,15 +1134,19 @@ definitions:
         description: ID of this template.
         type: string
       issuer:
-        description: ID of the issuer that will be issuance the credentials.
+        description: ID of the issuer that will be issuing the credentials.
         type: string
-      issuerKid:
-        description: ID of the key that will be used to sign the credentials.
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the credentials.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
         type: string
     required:
     - credentialManifest
     - issuer
-    - issuerKid
+    - verificationMethodId
     type: object
   pkg_server_router.CreateManifestRequest:
     properties:
@@ -1140,11 +1165,6 @@ definitions:
       issuerDid:
         description: |-
           DID that identifies who the issuer of the credential(s) will be.
-          Required.
-        type: string
-      issuerKid:
-        description: |-
-          The KID of the private key that will be used when signing issued credentials.
           Required.
         type: string
       issuerName:
@@ -1171,11 +1191,19 @@ definitions:
         description: id of the presentation definition created with PresentationDefinitionAPI.
           Must be empty if `value` is present.
         type: string
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the issued credentials.
+          Required.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - format
     - issuerDid
-    - issuerKid
     - outputDescriptors
+    - verificationMethodId
     type: object
   pkg_server_router.CreateManifestRequestRequest:
     properties:
@@ -1195,19 +1223,21 @@ definitions:
           Optional.
         type: string
       issuerId:
-        description: |-
-          DID of the issuer of this presentation definition. The DID must have been previously created with the DID API,
-          or the PrivateKey must have been added independently.
+        description: DID of the issuer of this presentation definition. The DID must
+          have been previously created with the DID API.
         type: string
-      issuerKid:
+      verificationMethodId:
         description: |-
-          The privateKey associated with the KID will be used to sign an envelope that contains
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuerId`.
+          The private key associated with the verificationMethod's publicKey will be used to sign an envelope that contains
           the created presentation definition.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
         type: string
     required:
     - credentialManifestId
     - issuerId
-    - issuerKid
+    - verificationMethodId
     type: object
   pkg_server_router.CreateManifestRequestResponse:
     properties:
@@ -1263,22 +1293,24 @@ definitions:
           Optional.
         type: string
       issuerId:
-        description: |-
-          DID of the issuer of this presentation definition. The DID must have been previously created with the DID API,
-          or the PrivateKey must have been added independently.
-        type: string
-      issuerKid:
-        description: |-
-          The privateKey associated with the KID will be used to sign an envelope that contains
-          the created presentation definition.
+        description: DID of the issuer of this presentation definition. The DID must
+          have been previously created with the DID API.
         type: string
       presentationDefinitionId:
         description: ID of the presentation definition to use for this request.
         type: string
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuerId`.
+          The private key associated with the verificationMethod's publicKey will be used to sign an envelope that contains
+          the created presentation definition.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - issuerId
-    - issuerKid
     - presentationDefinitionId
+    - verificationMethodId
     type: object
   pkg_server_router.CreateRequestResponse:
     properties:
@@ -1295,11 +1327,6 @@ definitions:
           Issuer represents the DID of the issuer for the schema if it's signed. Required if intending to sign the
           schema as a credential using CredentialSchema2023.
         type: string
-      issuerKid:
-        description: |-
-          IssuerKID represents the KID of the issuer's private key to sign the schema. Required if intending to sign the
-          schema as a credential using CredentialSchema2023.
-        type: string
       name:
         description: Name is a human-readable name for a schema
         type: string
@@ -1312,11 +1339,20 @@ definitions:
           The schema must be against draft 2020-12, 2019-09, or 7.
           Must include a string field `$schema` that must be one of `https://json-schema.org/draft/2020-12/schema`,
           `https://json-schema.org/draft/2019-09/schema`, or `https://json-schema.org/draft-07/schema`.
+      verificationMethodId:
+        description: |-
+          The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+          stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+          The private key associated with the verificationMethod's publicKey will be used to sign the schema as a
+          credential using CredentialSchema2023.
+          Required if intending to sign the schema as a credential using CredentialSchema2023.
+        example: did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3
+        type: string
     required:
     - issuer
-    - issuerKid
     - name
     - schema
+    - verificationMethodId
     type: object
   pkg_server_router.CreateSchemaResponse:
     properties:
@@ -1391,16 +1427,19 @@ definitions:
           using JWS. In other words, the `proof` field is not present. See `credentialJwt` for the secured Verifiable
           Credential.
       credentialJwt:
-        description: JWT representation of `credential`, secured with an external
-          proof signed by `issuerKid`.
+        description: |-
+          JWT representation of `credential`, secured with an external proof. Verification can be done according to
+          `fullyQualifiedVerificationMethodId`.
+        type: string
+      fullyQualifiedVerificationMethodId:
+        description: |-
+          Fully qualified verification method ID that can be used to verify the credential. For example
+          `did:ion:EiDpQBo_nEfuLVeppgmPVQNEhtrnZLWFsB9ziZUuaKCJ3Q#83526c36-136c-423b-a57a-f190b83ae531`.
         type: string
       id:
         description: |-
           UUID assigned by the ssi-service. For example, 48958871-6a6d-4a25-889f-88c9c6835780. The `credential.id`
           value will be a URL that can be dereferenced, which includes this ID.
-        type: string
-      issuerKid:
-        description: The KID of the private key used to sign `credentialJwt`.
         type: string
       revoked:
         description: Whether this credential is currently revoked.

--- a/integration/common.go
+++ b/integration/common.go
@@ -131,12 +131,12 @@ func CreateKYCSchema() (string, error) {
 }
 
 type credInputParams struct {
-	IssuerID    string
-	IssuerKID   string
-	SchemaID    string
-	SubjectID   string
-	Revocable   bool
-	Suspendable bool
+	IssuerID             string
+	VerificationMethodID string
+	SchemaID             string
+	SubjectID            string
+	Revocable            bool
+	Suspendable          bool
 }
 
 func CreateVerifiableCredential(credentialInput credInputParams) (string, error) {
@@ -181,15 +181,15 @@ func CreateVerifiableCredential(credentialInput credInputParams) (string, error)
 }
 
 type batchCredInputParams struct {
-	IssuerID     string
-	IssuerKID    string
-	SchemaID     string
-	SubjectID0   string
-	Revocable0   bool
-	Suspendable0 bool
-	SubjectID1   string
-	Revocable1   bool
-	Suspendable1 bool
+	IssuerID             string
+	VerificationMethodID string
+	SchemaID             string
+	SubjectID0           string
+	Revocable0           bool
+	Suspendable0         bool
+	SubjectID1           string
+	Revocable1           bool
+	Suspendable1         bool
 }
 
 func BatchCreateVerifiableCredentials(credentialInput batchCredInputParams) (string, error) {
@@ -214,12 +214,12 @@ func BatchCreate100VerifiableCredentials(credentialInput credInputParams) (strin
 	creds := make([]any, 0)
 	for i := 0; i < 100; i++ {
 		credentialInput, err := resolveTemplate(credInputParams{
-			IssuerID:    credentialInput.IssuerID,
-			IssuerKID:   credentialInput.IssuerKID,
-			SchemaID:    credentialInput.SchemaID,
-			SubjectID:   credentialInput.SubjectID,
-			Revocable:   true,
-			Suspendable: false,
+			IssuerID:             credentialInput.IssuerID,
+			VerificationMethodID: credentialInput.VerificationMethodID,
+			SchemaID:             credentialInput.SchemaID,
+			SubjectID:            credentialInput.SubjectID,
+			Revocable:            true,
+			Suspendable:          false,
 		}, "credential-input.json")
 		if err != nil {
 			return "", err
@@ -278,9 +278,9 @@ func resolveTemplate(input any, fileName string) (string, error) {
 }
 
 type credManifestParams struct {
-	IssuerID  string
-	IssuerKID string
-	SchemaID  string
+	IssuerID             string
+	VerificationMethodID string
+	SchemaID             string
 }
 
 func CreateCredentialManifest(credManifest credManifestParams) (string, error) {
@@ -628,10 +628,10 @@ func ReviewApplication(params reviewApplicationParams) (string, error) {
 }
 
 type issuanceTemplateParams struct {
-	SchemaID   string
-	ManifestID string
-	IssuerID   string
-	IssuerKID  string
+	SchemaID             string
+	ManifestID           string
+	IssuerID             string
+	VerificationMethodID string
 }
 
 func CreateIssuanceTemplate(params issuanceTemplateParams) (string, error) {

--- a/integration/credential_manifest_integration_test.go
+++ b/integration/credential_manifest_integration_test.go
@@ -26,10 +26,10 @@ func TestCreateIssuerDIDKeyIntegration(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:key")
 	SetValue(credentialManifestContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(credentialManifestContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(credentialManifestContext, "verificationMethodID", verificationMethodID)
 }
 
 func TestCreateAliceDIDKeyIntegration(t *testing.T) {
@@ -79,19 +79,19 @@ func TestCreateVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialManifestContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialManifestContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialManifestContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcOutput, err := CreateVerifiableCredential(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
-		SubjectID: issuerDID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)
@@ -111,22 +111,22 @@ func TestBatchCreateCredentialsIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialManifestContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialManifestContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialManifestContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcsOutput, err := BatchCreateVerifiableCredentials(batchCredInputParams{
-		IssuerID:   issuerDID.(string),
-		IssuerKID:  issuerKID.(string),
-		SchemaID:   schemaID.(string),
-		SubjectID0: issuerDID.(string),
-		SubjectID1: issuerDID.(string),
-		Revocable0: false,
-		Revocable1: true,
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID0:           issuerDID.(string),
+		SubjectID1:           issuerDID.(string),
+		Revocable0:           false,
+		Revocable1:           true,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcsOutput)
@@ -149,9 +149,9 @@ func TestBatchCreate100CredentialsIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialManifestContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialManifestContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialManifestContext, "schemaID")
 	assert.NoError(t, err)
@@ -159,10 +159,10 @@ func TestBatchCreate100CredentialsIntegration(t *testing.T) {
 
 	// This test is simply about making sure we can create the maximum configured by default.
 	vcsOutput, err := BatchCreate100VerifiableCredentials(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
-		SubjectID: issuerDID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcsOutput)
@@ -177,18 +177,18 @@ func TestCreateCredentialManifestIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialManifestContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialManifestContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialManifestContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	cmOutput, err := CreateCredentialManifest(credManifestParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
 	})
 	assert.NoError(t, err)
 
@@ -212,18 +212,18 @@ func TestCreateIssuanceTemplateIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialManifestContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialManifestContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialManifestContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	cmOutput, err := CreateCredentialManifest(credManifestParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
 	})
 	assert.NoError(t, err)
 
@@ -238,10 +238,10 @@ func TestCreateIssuanceTemplateIntegration(t *testing.T) {
 	SetValue(credentialManifestContext, "presentationDefinitionWithIssuanceTemplateID", presentationDefinitionID)
 
 	itOutput, err := CreateIssuanceTemplate(issuanceTemplateParams{
-		SchemaID:   schemaID.(string),
-		ManifestID: manifestID,
-		IssuerID:   issuerDID.(string),
-		IssuerKID:  issuerKID.(string),
+		SchemaID:             schemaID.(string),
+		ManifestID:           manifestID,
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
 	})
 	assert.NoError(t, err)
 

--- a/integration/credential_revocation_concurrency_integration_test.go
+++ b/integration/credential_revocation_concurrency_integration_test.go
@@ -19,9 +19,9 @@ func TestCreateRevocationVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, issuerDID, "did:key")
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaOutput, err := CreateKYCSchema()
 	assert.NoError(t, err)
@@ -30,7 +30,7 @@ func TestCreateRevocationVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
-	vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, IssuerKID: issuerKID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
+	vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, VerificationMethodID: verificationMethodID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)
 
@@ -57,9 +57,9 @@ func TestCreateRevocationVerifiableCredentialShareStatusListIntegration(t *testi
 	assert.NoError(t, err)
 	assert.Contains(t, issuerDID, "did:key")
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaOutput, err := CreateKYCSchema()
 	assert.NoError(t, err)
@@ -68,7 +68,7 @@ func TestCreateRevocationVerifiableCredentialShareStatusListIntegration(t *testi
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
-	vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, IssuerKID: issuerKID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
+	vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, VerificationMethodID: verificationMethodID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)
 
@@ -82,7 +82,7 @@ func TestCreateRevocationVerifiableCredentialShareStatusListIntegration(t *testi
 	assert.NotEmpty(t, credStatusListURL)
 	assert.Contains(t, credStatusListURL, "http")
 
-	vcOutputTwo, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, IssuerKID: issuerKID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
+	vcOutputTwo, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, VerificationMethodID: verificationMethodID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutputTwo)
 
@@ -111,9 +111,9 @@ func TestConcurrencyRevocationVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, issuerDID, "did:key")
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaOutput, err := CreateKYCSchema()
 	assert.NoError(t, err)
@@ -135,7 +135,7 @@ func TestConcurrencyRevocationVerifiableCredentialIntegration(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, IssuerKID: issuerKID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
+			vcOutput, err := CreateVerifiableCredential(credInputParams{IssuerID: issuerDID, VerificationMethodID: verificationMethodID, SchemaID: schemaID, SubjectID: issuerDID, Revocable: true})
 
 			// We're hammering the DB, so some calls might fail due to internal timeouts or similar. Upon failure, we
 			// shouldn't check any assertions, since we know they'll fail.

--- a/integration/credential_revocation_integration_test.go
+++ b/integration/credential_revocation_integration_test.go
@@ -24,10 +24,10 @@ func TestRevocationCreateIssuerDIDKeyIntegration(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:key")
 	SetValue(credentialRevocationContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(credentialRevocationContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(credentialRevocationContext, "verificationMethodID", verificationMethodID)
 }
 
 func TestRevocationCreateSchemaIntegration(t *testing.T) {
@@ -53,20 +53,20 @@ func TestRevocationCreateVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialRevocationContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialRevocationContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialRevocationContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcOutput, err := CreateVerifiableCredential(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
-		SubjectID: issuerDID.(string),
-		Revocable: true,
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
+		Revocable:            true,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)

--- a/integration/credential_suspension_integration_test.go
+++ b/integration/credential_suspension_integration_test.go
@@ -25,10 +25,10 @@ func TestSuspensionCreateIssuerDIDKeyIntegration(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:key")
 	SetValue(credentialSuspensionContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(credentialSuspensionContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(credentialSuspensionContext, "verificationMethodID", verificationMethodID)
 }
 
 func TestSuspensionCreateSchemaIntegration(t *testing.T) {
@@ -54,20 +54,20 @@ func TestSuspensionCreateVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(credentialSuspensionContext, "issuerKID")
+	verificationMethodID, err := GetValue(credentialSuspensionContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(credentialSuspensionContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcOutput, err := CreateVerifiableCredential(credInputParams{
-		IssuerID:    issuerDID.(string),
-		IssuerKID:   issuerKID.(string),
-		SchemaID:    schemaID.(string),
-		SubjectID:   issuerDID.(string),
-		Suspendable: true,
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
+		Suspendable:          true,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)

--- a/integration/didion_integration_test.go
+++ b/integration/didion_integration_test.go
@@ -39,10 +39,10 @@ func TestCreateIssuerDIDIONIntegration(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:ion")
 	SetValue(didIONContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didIONOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didIONOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(didIONContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(didIONContext, "verificationMethodID", verificationMethodID)
 
 	verificationMethod1ID, err := getJSONElement(didIONOutput, "$.did.verificationMethod[1].id")
 	assert.NoError(t, err)
@@ -114,19 +114,19 @@ func TestDIDIONCreateVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(didIONContext, "issuerKID")
+	verificationMethodID, err := GetValue(didIONContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(didIONContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcOutput, err := CreateVerifiableCredential(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
-		SubjectID: issuerDID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)
@@ -146,18 +146,18 @@ func TestDIDIONCreateCredentialManifestIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(didIONContext, "issuerKID")
+	verificationMethodID, err := GetValue(didIONContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(didIONContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	cmOutput, err := CreateCredentialManifest(credManifestParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
 	})
 	assert.NoError(t, err)
 

--- a/integration/didweb_integration_test.go
+++ b/integration/didweb_integration_test.go
@@ -25,10 +25,10 @@ func TestCreateIssuerDIDWebIntegration(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:web")
 	SetValue(didWebContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didWebOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didWebOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(didWebContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(didWebContext, "verificationMethodID", verificationMethodID)
 }
 
 func TestListDIDWebIntegration(t *testing.T) {
@@ -93,19 +93,19 @@ func TestDIDWebCreateVerifiableCredentialIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(didWebContext, "issuerKID")
+	verificationMethodID, err := GetValue(didWebContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(didWebContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	vcOutput, err := CreateVerifiableCredential(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
-		SubjectID: issuerDID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
+		SubjectID:            issuerDID.(string),
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcOutput)
@@ -125,18 +125,18 @@ func TestDIDWebCreateCredentialManifestIntegration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, issuerDID)
 
-	issuerKID, err := GetValue(didWebContext, "issuerKID")
+	verificationMethodID, err := GetValue(didWebContext, "verificationMethodID")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
 
 	schemaID, err := GetValue(didWebContext, "schemaID")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, schemaID)
 
 	cmOutput, err := CreateCredentialManifest(credManifestParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SchemaID:  schemaID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SchemaID:             schemaID.(string),
 	})
 	assert.NoError(t, err)
 

--- a/integration/presentation_exchange_integration_test.go
+++ b/integration/presentation_exchange_integration_test.go
@@ -26,10 +26,10 @@ func TestCreateParticipants(t *testing.T) {
 	assert.Contains(t, issuerDID, "did:key")
 	SetValue(presentationExchangeContext, "issuerDID", issuerDID)
 
-	issuerKID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
+	verificationMethodID, err := getJSONElement(didKeyOutput, "$.did.verificationMethod[0].id")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, issuerKID)
-	SetValue(presentationExchangeContext, "issuerKID", issuerKID)
+	assert.NotEmpty(t, verificationMethodID)
+	SetValue(presentationExchangeContext, "verificationMethodID", verificationMethodID)
 
 	holderPrivateKey, holderDIDKey, err := key.GenerateDIDKey(crypto.Ed25519)
 	assert.NoError(t, err)
@@ -102,13 +102,13 @@ func TestSubmissionFlow(t *testing.T) {
 	issuerDID, err := GetValue(presentationExchangeContext, "issuerDID")
 	assert.NoError(t, err)
 
-	issuerKID, err := GetValue(presentationExchangeContext, "issuerKID")
+	verificationMethodID, err := GetValue(presentationExchangeContext, "verificationMethodID")
 	assert.NoError(t, err)
 
 	credOutput, err := CreateSubmissionCredential(credInputParams{
-		IssuerID:  issuerDID.(string),
-		IssuerKID: issuerKID.(string),
-		SubjectID: holderDID.(string),
+		IssuerID:             issuerDID.(string),
+		VerificationMethodID: verificationMethodID.(string),
+		SubjectID:            holderDID.(string),
 	})
 	assert.NoError(t, err)
 

--- a/integration/testdata/batch-create-credential-input.json
+++ b/integration/testdata/batch-create-credential-input.json
@@ -16,7 +16,7 @@
         "taxId":"123"
       },
       "issuer": "{{.IssuerID}}",
-      "issuerKid": "{{.IssuerKID}}",
+      "verificationMethodId": "{{.VerificationMethodID}}",
       "subject": "{{.SubjectID0}}",
       "@context":"https://www.w3.org/2018/credentials/v1",
       "expiry": "2051-10-05T14:48:00.000Z",
@@ -40,7 +40,7 @@
         "taxId":"123"
       },
       "issuer": "{{.IssuerID}}",
-      "issuerKid": "{{.IssuerKID}}",
+      "verificationMethodId": "{{.VerificationMethodID}}",
       "subject": "{{.SubjectID1}}",
       "@context":"https://www.w3.org/2018/credentials/v1",
       "expiry": "2051-10-05T14:48:00.000Z",

--- a/integration/testdata/credential-input.json
+++ b/integration/testdata/credential-input.json
@@ -14,7 +14,7 @@
     "taxId":"123"
   },
   "issuer": "{{.IssuerID}}",
-  "issuerKid": "{{.IssuerKID}}",
+  "verificationMethodId": "{{.VerificationMethodID}}",
   "subject": "{{.SubjectID}}",
   "@context":"https://www.w3.org/2018/credentials/v1",
   "expiry": "2051-10-05T14:48:00.000Z",

--- a/integration/testdata/issuance-template-input.json
+++ b/integration/testdata/issuance-template-input.json
@@ -1,7 +1,7 @@
 {
   "credentialManifest": "{{.ManifestID}}",
   "issuer": "{{.IssuerID}}",
-  "issuerKid": "{{.IssuerKID}}",
+  "verificationMethodId": "{{.VerificationMethodID}}",
   "credentials": [
     {
       "id": "kyc_credential",

--- a/integration/testdata/manifest-input.json
+++ b/integration/testdata/manifest-input.json
@@ -1,6 +1,6 @@
 {
   "issuerDid":"{{.IssuerID}}",
-  "issuerKid": "{{.IssuerKID}}",
+  "verificationMethodId": "{{.VerificationMethodID}}",
   "issuerName":"Issuer Name Lol",
   "format":{
     "jwt":{

--- a/integration/testdata/submission-credential-input.json
+++ b/integration/testdata/submission-credential-input.json
@@ -6,7 +6,7 @@
     "givenName": "Uribe"
   },
   "issuer": "{{.IssuerID}}",
-  "issuerKid": "{{.IssuerKID}}",
+  "verificationMethodId": "{{.VerificationMethodID}}",
   "subject": "{{.SubjectID}}",
   "expiry": "2051-10-05T14:48:00.000Z"
 }

--- a/internal/credential/model.go
+++ b/internal/credential/model.go
@@ -19,15 +19,17 @@ type Container struct {
 	// value will be a URL that can be dereferenced, which includes this ID.
 	ID string `json:"id,omitempty"`
 
-	// The KID of the private key used to sign `credentialJwt`.
-	IssuerKID string `json:"issuerKid,omitempty"`
+	// Fully qualified verification method ID that can be used to verify the credential. For example
+	// `did:ion:EiDpQBo_nEfuLVeppgmPVQNEhtrnZLWFsB9ziZUuaKCJ3Q#83526c36-136c-423b-a57a-f190b83ae531`.
+	FullyQualifiedVerificationMethodID string `json:"fullyQualifiedVerificationMethodId,omitempty"`
 
 	// Verifiable Credential in the `application/vc+ld+json` format. The credential is secured with an external proof
 	// using JWS. In other words, the `proof` field is not present. See `credentialJwt` for the secured Verifiable
 	// Credential.
 	Credential *credential.VerifiableCredential `json:"credential,omitempty"`
 
-	// JWT representation of `credential`, secured with an external proof signed by `issuerKid`.
+	// JWT representation of `credential`, secured with an external proof. Verification can be done according to
+	// `fullyQualifiedVerificationMethodId`.
 	CredentialJWT *keyaccess.JWT `json:"credentialJwt,omitempty"`
 
 	// Whether this credential is currently revoked.

--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -100,8 +100,10 @@ type CreateCredentialRequest struct {
 	// The issuer id.
 	Issuer string `json:"issuer" validate:"required" example:"did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3"`
 
-	// The KID used to sign the credential.
-	IssuerKID string `json:"issuerKid" validate:"required" example:"did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3"`
+	// The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+	// stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+	// The private key associated with the verificationMethod's publicKey will be used to sign the credential.
+	VerificationMethodID string `json:"verificationMethodId" validate:"required" example:"did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3"`
 
 	// The subject id.
 	Subject string `json:"subject" validate:"required" example:"did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"`
@@ -132,7 +134,7 @@ type CreateCredentialRequest struct {
 }
 
 func (c CreateCredentialRequest) toServiceRequest() credential.CreateCredentialRequest {
-	verificationMethodID := did.FullyQualifiedVerificationMethodID(c.Issuer, c.IssuerKID)
+	verificationMethodID := did.FullyQualifiedVerificationMethodID(c.Issuer, c.VerificationMethodID)
 	return credential.CreateCredentialRequest{
 		Issuer:                             c.Issuer,
 		FullyQualifiedVerificationMethodID: verificationMethodID,

--- a/pkg/server/router/credential_test.go
+++ b/pkg/server/router/credential_test.go
@@ -801,12 +801,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Create Suspendable Credential", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -857,12 +857,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Update Suspendable Credential To Suspended", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -935,12 +935,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Update Suspendable Credential To Suspended then Unsuspended", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1018,12 +1018,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Create Suspendable and Revocable Credential Should Be Error", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1040,12 +1040,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Update Suspendable and Revocable Credential Should Be Error", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1065,12 +1065,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Update Suspended On Revoked Credential Should Be Error", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1090,12 +1090,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Create Credential With Invalid Evidence", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				_, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1109,7 +1109,7 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Create Credential With Invalid Evidence No Id", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				evidenceMap := map[string]any{
@@ -1123,7 +1123,7 @@ func TestCredentialRouter(t *testing.T) {
 
 				_, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1137,12 +1137,12 @@ func TestCredentialRouter(t *testing.T) {
 			})
 
 			t.Run("Create Credential With Evidence", func(tt *testing.T) {
-				issuer, issuerKID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
+				issuer, verificationMethodID, schemaID, credService := createCredServicePrereqs(tt, test.ServiceStorage(t))
 				subject := "did:test:345"
 
 				createdCred, err := credService.CreateCredential(context.Background(), credential.CreateCredentialRequest{
 					Issuer:                             issuer,
-					FullyQualifiedVerificationMethodID: issuerKID,
+					FullyQualifiedVerificationMethodID: verificationMethodID,
 					Subject:                            subject,
 					SchemaID:                           schemaID,
 					Data: map[string]any{
@@ -1166,7 +1166,7 @@ func idFromURI(cred string) string {
 	return cred[len(cred)-36:]
 }
 
-func createCredServicePrereqs(tt *testing.T, s storage.ServiceStorage) (issuer, issuerKID, schemaID string, credSvc credential.Service) {
+func createCredServicePrereqs(tt *testing.T, s storage.ServiceStorage) (issuer, verificationMethodID, schemaID string, credSvc credential.Service) {
 	require.NotEmpty(tt, s)
 
 	serviceConfig := config.CredentialServiceConfig{BaseServiceConfig: &config.BaseServiceConfig{Name: "credential", ServiceEndpoint: "http://localhost:1234/v1/credentials"}}

--- a/pkg/server/router/manifest.go
+++ b/pkg/server/router/manifest.go
@@ -57,9 +57,11 @@ type CreateManifestRequest struct {
 	// Required.
 	IssuerDID string `json:"issuerDid" validate:"required"`
 
-	// The KID of the private key that will be used when signing issued credentials.
+	// The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+	// stored in ssi-service. The verificationMethod must be part of the did document associated with `issuer`.
+	// The private key associated with the verificationMethod's publicKey will be used to sign the issued credentials.
 	// Required.
-	IssuerKID string `json:"issuerKid" validate:"required"`
+	VerificationMethodID string `json:"verificationMethodId" validate:"required" example:"did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3"`
 
 	// Human-readable name the Issuer wishes to be recognized by.
 	// Optional.
@@ -80,7 +82,7 @@ type CreateManifestRequest struct {
 }
 
 func (c CreateManifestRequest) ToServiceRequest() model.CreateManifestRequest {
-	verificationMethodID := did.FullyQualifiedVerificationMethodID(c.IssuerDID, c.IssuerKID)
+	verificationMethodID := did.FullyQualifiedVerificationMethodID(c.IssuerDID, c.VerificationMethodID)
 	return model.CreateManifestRequest{
 		Name:                               c.Name,
 		Description:                        c.Description,
@@ -750,9 +752,9 @@ func (mr ManifestRouter) DeleteRequest(c *gin.Context) {
 
 func commonRequestToServiceRequest(request *CommonCreateRequestRequest) (*common.Request, error) {
 	req := &common.Request{
-		Audience:  request.Audience,
-		IssuerDID: request.IssuerDID,
-		IssuerKID: request.IssuerKID,
+		Audience:             request.Audience,
+		IssuerDID:            request.IssuerDID,
+		VerificationMethodID: request.VerificationMethodID,
 	}
 	if request.Expiration != "" {
 		expiration, err := time.Parse(time.RFC3339, request.Expiration)

--- a/pkg/server/router/manifest_test.go
+++ b/pkg/server/router/manifest_test.go
@@ -56,7 +56,7 @@ func TestManifestRouter(t *testing.T) {
 
 				tt.Run("CreateManifest with presentation ID and value error", func(ttt *testing.T) {
 					defID := "an ID I know"
-					createManifestRequest := getValidManifestRequest("issuerDID", "issuerKID", "schemaID")
+					createManifestRequest := getValidManifestRequest("did:ion:hello", "did:ion:hello#123", "schemaID")
 					createManifestRequest.PresentationDefinitionRef.ID = &defID
 
 					_, err := manifestService.CreateManifest(context.Background(), createManifestRequest)
@@ -67,7 +67,7 @@ func TestManifestRouter(t *testing.T) {
 
 				tt.Run("CreateManifest with bad presentation ID returns error", func(ttt *testing.T) {
 					defID := "a bad ID"
-					createManifestRequest := getValidManifestRequest("issuerDID", "issuerKID", "schemaID")
+					createManifestRequest := getValidManifestRequest("did:ion:hello", "did:ion:hello#123", "schemaID")
 					createManifestRequest.PresentationDefinitionRef = &model.PresentationDefinitionRef{
 						ID: &defID,
 					}
@@ -86,7 +86,7 @@ func TestManifestRouter(t *testing.T) {
 					assert.NoError(ttt, err)
 					assert.NotEmpty(ttt, resp)
 
-					createManifestRequest := getValidManifestRequest("issuerDID", "issuerKID", "schemaID")
+					createManifestRequest := getValidManifestRequest("did:ion:hello", "did:ion:hello#123", "schemaID")
 					createManifestRequest.PresentationDefinitionRef = &model.PresentationDefinitionRef{
 						ID: &resp.PresentationDefinition.ID,
 					}
@@ -139,7 +139,7 @@ func TestManifestRouter(t *testing.T) {
 						},
 					}
 					kid := issuerDID.DID.VerificationMethod[0].ID
-					createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: licenseSchema})
+					createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: licenseSchema})
 					assert.NoError(ttt, err)
 					assert.NotEmpty(ttt, createdSchema)
 
@@ -234,10 +234,10 @@ func getValidManifestRequestRequest(issuerDID *did.CreateDIDResponse, kid string
 	return model.CreateRequestRequest{
 		ManifestRequest: model.Request{
 			Request: common.Request{
-				Audience:   []string{"mario"},
-				IssuerDID:  issuerDID.DID.ID,
-				IssuerKID:  kid,
-				Expiration: &In100Seconds,
+				Audience:             []string{"mario"},
+				IssuerDID:            issuerDID.DID.ID,
+				VerificationMethodID: kid,
+				Expiration:           &In100Seconds,
 			},
 			ManifestID: createdManifest.Manifest.ID,
 		},
@@ -245,10 +245,10 @@ func getValidManifestRequestRequest(issuerDID *did.CreateDIDResponse, kid string
 }
 
 // getValidManifestRequest returns a valid manifest request, expecting a single JWT-VC EdDSA credential
-func getValidManifestRequest(issuerDID, issuerKID, schemaID string) model.CreateManifestRequest {
+func getValidManifestRequest(issuerDID, fullyQualifiedVerificationMethodID, schemaID string) model.CreateManifestRequest {
 	createManifestRequest := model.CreateManifestRequest{
 		IssuerDID:                          issuerDID,
-		FullyQualifiedVerificationMethodID: issuerKID,
+		FullyQualifiedVerificationMethodID: fullyQualifiedVerificationMethodID,
 		ClaimFormat: &exchange.ClaimFormat{
 			JWTVC: &exchange.JWTType{Alg: []crypto.SignatureAlgorithm{crypto.EdDSA}},
 		},

--- a/pkg/server/router/model.go
+++ b/pkg/server/router/model.go
@@ -9,11 +9,12 @@ type CommonCreateRequestRequest struct {
 	// Optional.
 	Expiration string `json:"expiration"`
 
-	// DID of the issuer of this presentation definition. The DID must have been previously created with the DID API,
-	// or the PrivateKey must have been added independently.
+	// DID of the issuer of this presentation definition. The DID must have been previously created with the DID API.
 	IssuerDID string `json:"issuerId" validate:"required"`
 
-	// The privateKey associated with the KID will be used to sign an envelope that contains
+	// The id of the verificationMethod (see https://www.w3.org/TR/did-core/#verification-methods) who's privateKey is
+	// stored in ssi-service. The verificationMethod must be part of the did document associated with `issuerId`.
+	// The private key associated with the verificationMethod's publicKey will be used to sign an envelope that contains
 	// the created presentation definition.
-	IssuerKID string `json:"issuerKid" validate:"required"`
+	VerificationMethodID string `json:"verificationMethodId" validate:"required" example:"did:key:z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3#z6MkkZDjunoN4gyPMx5TSy7Mfzw22D2RZQZUcx46bii53Ex3"`
 }

--- a/pkg/server/router/presentation_test.go
+++ b/pkg/server/router/presentation_test.go
@@ -119,10 +119,10 @@ func TestPresentationDefinitionService(t *testing.T) {
 				assert.NoError(t, err)
 				expectedReq := model.Request{
 					Request: common.Request{
-						Audience:   []string{"did:web:heman"},
-						IssuerDID:  authorDID.DID.ID,
-						IssuerKID:  authorDID.DID.VerificationMethod[0].ID,
-						Expiration: &SampleExpirationTime,
+						Audience:             []string{"did:web:heman"},
+						IssuerDID:            authorDID.DID.ID,
+						VerificationMethodID: authorDID.DID.VerificationMethod[0].ID,
+						Expiration:           &SampleExpirationTime,
 					},
 					PresentationDefinitionID: pd.ID,
 				}
@@ -141,7 +141,7 @@ func TestPresentationDefinitionService(t *testing.T) {
 				assert.Equal(t, *pd, got.PresentationDefinition)
 				assert.Equal(t, expectedReq.Audience, req.Audience)
 				assert.Equal(t, expectedReq.IssuerDID, req.IssuerDID)
-				assert.Equal(t, expectedReq.IssuerKID, req.IssuerKID)
+				assert.Equal(t, expectedReq.VerificationMethodID, req.VerificationMethodID)
 				assert.Equal(t, expectedReq.PresentationDefinitionID, req.PresentationDefinitionID)
 				assert.Equal(t, expectedReq.Expiration, req.Expiration)
 			})
@@ -155,10 +155,10 @@ func TestPresentationDefinitionService(t *testing.T) {
 				req, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
 					PresentationRequest: model.Request{
 						Request: common.Request{
-							Audience:   []string{"did:web:heman"},
-							IssuerDID:  authorDID.DID.ID,
-							IssuerKID:  authorDID.DID.VerificationMethod[0].ID,
-							Expiration: &In30Seconds,
+							Audience:             []string{"did:web:heman"},
+							IssuerDID:            authorDID.DID.ID,
+							VerificationMethodID: authorDID.DID.VerificationMethod[0].ID,
+							Expiration:           &In30Seconds,
 						},
 						PresentationDefinitionID: pd.ID,
 					},
@@ -179,9 +179,9 @@ func TestPresentationDefinitionService(t *testing.T) {
 				req, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
 					PresentationRequest: model.Request{
 						Request: common.Request{
-							IssuerDID:  authorDID.DID.ID,
-							IssuerKID:  authorDID.DID.VerificationMethod[0].ID,
-							Expiration: &In30Seconds,
+							IssuerDID:            authorDID.DID.ID,
+							VerificationMethodID: authorDID.DID.VerificationMethod[0].ID,
+							Expiration:           &In30Seconds,
 						},
 						PresentationDefinitionID: pd.ID,
 					},
@@ -200,8 +200,8 @@ func TestPresentationDefinitionService(t *testing.T) {
 				_, err := service.CreateRequest(context.Background(), model.CreateRequestRequest{
 					PresentationRequest: model.Request{
 						Request: common.Request{
-							IssuerDID: "issuer id",
-							IssuerKID: "kid",
+							IssuerDID:            "issuer id",
+							VerificationMethodID: "kid",
 						},
 					},
 				})
@@ -222,7 +222,7 @@ func TestPresentationDefinitionService(t *testing.T) {
 				_, err = service.CreateRequest(context.Background(), model.CreateRequestRequest{
 					PresentationRequest: model.Request{
 						Request: common.Request{
-							IssuerKID: "kid",
+							VerificationMethodID: "kid",
 						},
 						PresentationDefinitionID: "something",
 					},

--- a/pkg/server/server_credential_test.go
+++ b/pkg/server/server_credential_test.go
@@ -51,9 +51,9 @@ func TestCredentialAPI(t *testing.T) {
 				batchCreateCredentialsRequest := router.BatchCreateCredentialsRequest{
 					Requests: []router.CreateCredentialRequest{
 						{
-							Issuer:    issuerDID.DID.ID,
-							IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-							Subject:   "did:abc:456",
+							Issuer:               issuerDID.DID.ID,
+							VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+							Subject:              "did:abc:456",
 							Data: map[string]any{
 								"firstName": "Jack",
 								"lastName":  "Dorsey",
@@ -61,9 +61,9 @@ func TestCredentialAPI(t *testing.T) {
 							Expiry: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
 						},
 						{
-							Issuer:    issuerDID.DID.ID,
-							IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-							Subject:   "did:abc:789",
+							Issuer:               issuerDID.DID.ID,
+							VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+							Subject:              "did:abc:789",
 							Data: map[string]any{
 								"firstName": "Lemony",
 								"lastName":  "Snickets",
@@ -106,10 +106,10 @@ func TestCredentialAPI(t *testing.T) {
 					batchCreateCredentialsRequest := batchCreateCredentialsRequest
 					// missing the data field
 					batchCreateCredentialsRequest.Requests = append(batchCreateCredentialsRequest.Requests, router.CreateCredentialRequest{
-						Issuer:    issuerDID.DID.ID,
-						IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-						Subject:   "did:abc:456",
-						Expiry:    time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+						Issuer:               issuerDID.DID.ID,
+						VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+						Subject:              "did:abc:456",
+						Expiry:               time.Now().Add(24 * time.Hour).Format(time.RFC3339),
 					})
 
 					requestValue := newRequestValue(ttt, batchCreateCredentialsRequest)
@@ -156,10 +156,10 @@ func TestCredentialAPI(t *testing.T) {
 
 				// missing required field: data
 				badCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
-					Expiry:    time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
+					Expiry:               time.Now().Add(24 * time.Hour).Format(time.RFC3339),
 				}
 				badRequestValue := newRequestValue(ttt, badCredRequest)
 				req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/credentials", badRequestValue)
@@ -174,9 +174,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// missing known issuer request
 				missingIssuerRequest := router.CreateCredentialRequest{
-					Issuer:    "did:abc:123",
-					IssuerKID: "did:abc:123#key-1",
-					Subject:   "did:abc:456",
+					Issuer:               "did:abc:123",
+					VerificationMethodID: "did:abc:123#key-1",
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -194,9 +194,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good request
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -270,10 +270,10 @@ func TestCredentialAPI(t *testing.T) {
 				w := httptest.NewRecorder()
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
-					SchemaID:  createdSchema.ID,
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
+					SchemaID:             createdSchema.ID,
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -315,10 +315,10 @@ func TestCredentialAPI(t *testing.T) {
 
 				// create cred with unknown schema
 				missingSchemaCred := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
-					SchemaID:  "bad",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
+					SchemaID:             "bad",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -369,9 +369,9 @@ func TestCredentialAPI(t *testing.T) {
 				assert.NotEmpty(ttt, issuerDID)
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -453,10 +453,10 @@ func TestCredentialAPI(t *testing.T) {
 				assert.NotEmpty(ttt, createdSchema)
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
-					SchemaID:  createdSchema.ID,
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
+					SchemaID:             createdSchema.ID,
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -513,9 +513,9 @@ func TestCredentialAPI(t *testing.T) {
 				assert.NotEmpty(ttt, issuerDID)
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -571,9 +571,9 @@ func TestCredentialAPI(t *testing.T) {
 				assert.NotEmpty(ttt, issuerDID)
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -630,9 +630,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				subjectID := "did:abc:456"
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   subjectID,
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              subjectID,
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -687,9 +687,9 @@ func TestCredentialAPI(t *testing.T) {
 				assert.NotEmpty(ttt, issuerDID)
 
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -760,9 +760,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good request
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -841,9 +841,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good request One
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -867,9 +867,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good revocable request One
 				createRevocableCredRequestOne := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -899,9 +899,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good revocable request Two
 				createRevocableCredRequestTwo := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -931,9 +931,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good revocable request Three
 				createRevocableCredRequestThree := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -963,9 +963,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good revocable request Four (different issuer / schema)
 				createRevocableCredRequestFour := router.CreateCredentialRequest{
-					Issuer:    issuerDIDTwo.DID.ID,
-					IssuerKID: issuerDIDTwo.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDIDTwo.DID.ID,
+					VerificationMethodID: issuerDIDTwo.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -1014,9 +1014,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good request number one
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",
@@ -1090,9 +1090,9 @@ func TestCredentialAPI(t *testing.T) {
 
 				// good request number one
 				createCredRequest := router.CreateCredentialRequest{
-					Issuer:    issuerDID.DID.ID,
-					IssuerKID: issuerDID.DID.VerificationMethod[0].ID,
-					Subject:   "did:abc:456",
+					Issuer:               issuerDID.DID.ID,
+					VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+					Subject:              "did:abc:456",
 					Data: map[string]any{
 						"firstName": "Jack",
 						"lastName":  "Dorsey",

--- a/pkg/server/server_issuance_test.go
+++ b/pkg/server/server_issuance_test.go
@@ -43,9 +43,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "returns a template with ID",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: manifest.Manifest.ID,
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   manifest.Manifest.ID,
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "output_descriptor_1",
@@ -66,9 +66,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "returns a template with ID when schema is empty",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: manifest.Manifest.ID,
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   manifest.Manifest.ID,
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "output_descriptor_1",
@@ -114,9 +114,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "when missing output_descriptor_id",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: manifest.Manifest.ID,
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   manifest.Manifest.ID,
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "",
@@ -138,9 +138,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "when both times are set",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: manifest.Manifest.ID,
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   manifest.Manifest.ID,
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "output_descriptor_1",
@@ -163,9 +163,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "when credential schema does not exist",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: manifest.Manifest.ID,
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   manifest.Manifest.ID,
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "output_descriptor_1",
@@ -187,9 +187,9 @@ func TestIssuanceRouter(t *testing.T) {
 						name: "when credential manifest ID is does not exist",
 						request: router.CreateIssuanceTemplateRequest{
 							Template: issuance.Template{
-								CredentialManifest: "fake manifest id",
-								Issuer:             issuerResp.DID.ID,
-								IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+								CredentialManifest:   "fake manifest id",
+								Issuer:               issuerResp.DID.ID,
+								VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 								Credentials: []issuance.CredentialTemplate{
 									{
 										ID:     "output_descriptor_1",
@@ -247,9 +247,9 @@ func TestIssuanceRouter(t *testing.T) {
 				issuerResp, createdSchema, manifest, r := setupAllThings(tt, test.ServiceStorage(t))
 
 				inputTemplate := issuance.Template{
-					CredentialManifest: manifest.Manifest.ID,
-					Issuer:             issuerResp.DID.ID,
-					IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+					CredentialManifest:   manifest.Manifest.ID,
+					Issuer:               issuerResp.DID.ID,
+					VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 					Credentials: []issuance.CredentialTemplate{
 						{
 							ID:     "output_descriptor_1",
@@ -371,9 +371,9 @@ func createSimpleTemplate(t *testing.T, manifest *model.CreateManifestResponse, 
 	{
 		request := router.CreateIssuanceTemplateRequest{
 			Template: issuance.Template{
-				CredentialManifest: manifest.Manifest.ID,
-				Issuer:             issuerResp.DID.ID,
-				IssuerKID:          issuerResp.DID.VerificationMethod[0].ID,
+				CredentialManifest:   manifest.Manifest.ID,
+				Issuer:               issuerResp.DID.ID,
+				VerificationMethodID: issuerResp.DID.VerificationMethod[0].ID,
 				Credentials: []issuance.CredentialTemplate{
 					{
 						ID:     "output_descriptor_1",
@@ -431,7 +431,7 @@ func setupAllThings(t *testing.T, s storage.ServiceStorage) (*did.CreateDIDRespo
 		},
 	}
 	keyID := issuerResp.DID.VerificationMethod[0].ID
-	createdSchema, err := schemaSvc.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerResp.DID.ID, IssuerKID: keyID, Name: "license schema", Schema: licenseSchema})
+	createdSchema, err := schemaSvc.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerResp.DID.ID, FullyQualifiedVerificationMethodID: keyID, Name: "license schema", Schema: licenseSchema})
 	require.NoError(t, err)
 
 	sillyName := "some silly name"

--- a/pkg/server/server_manifest_test.go
+++ b/pkg/server/server_manifest_test.go
@@ -69,7 +69,7 @@ func TestManifestAPI(t *testing.T) {
 
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
-				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
+				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, createdSchema)
 
@@ -148,7 +148,7 @@ func TestManifestAPI(t *testing.T) {
 
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
-				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
+				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, createdSchema)
 
@@ -200,7 +200,7 @@ func TestManifestAPI(t *testing.T) {
 
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
-				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
+				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, createdSchema)
 
@@ -286,7 +286,7 @@ func TestManifestAPI(t *testing.T) {
 
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
-				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
+				createdSchema, err := schemaService.CreateSchema(context.Background(), schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, createdSchema)
 
@@ -368,14 +368,14 @@ func TestManifestAPI(t *testing.T) {
 				kid := issuerDID.DID.VerificationMethod[0].ID
 				licenseApplicationSchema, err := schemaService.CreateSchema(
 					context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseApplicationSchema)
 
 				// create a second schema for the creds to be issued after the application is approved
 				licenseSchema, err := schemaService.CreateSchema(
 					context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseSchema)
 
@@ -530,14 +530,14 @@ func TestManifestAPI(t *testing.T) {
 				kid := issuerDID.DID.VerificationMethod[0].ID
 				licenseApplicationSchema, err := schemaService.CreateSchema(
 					context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseApplicationSchema)
 
 				// create a second schema for the creds to be issued after the application is approved
 				licenseSchema, err := schemaService.CreateSchema(
 					context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseSchema)
 
@@ -697,7 +697,7 @@ func TestManifestAPI(t *testing.T) {
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
 				licenseApplicationSchema, err := schemaService.CreateSchema(context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseApplicationSchema)
 
@@ -843,13 +843,13 @@ func TestManifestAPI(t *testing.T) {
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
 				licenseApplicationSchema, err := schemaService.CreateSchema(context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license application schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseApplicationSchema)
 
 				licenseSchema, err := schemaService.CreateSchema(
 					context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, licenseSchema)
 				// issue a credential against the schema to the subject, from the issuer
@@ -1020,7 +1020,7 @@ func TestManifestAPI(t *testing.T) {
 				// create a schema for the creds to be issued against
 				kid := issuerDID.DID.VerificationMethod[0].ID
 				createdSchema, err := schemaService.CreateSchema(context.Background(),
-					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, IssuerKID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
+					schema.CreateSchemaRequest{Issuer: issuerDID.DID.ID, FullyQualifiedVerificationMethodID: kid, Name: "license schema", Schema: getLicenseApplicationSchema()})
 				assert.NoError(tt, err)
 				assert.NotEmpty(tt, createdSchema)
 
@@ -1117,9 +1117,9 @@ func TestManifestAPI(t *testing.T) {
 func getValidManifestRequestRequest(issuerDID *did.CreateDIDResponse, kid string, credentialManifest manifest.CredentialManifest) router.CreateManifestRequestRequest {
 	return router.CreateManifestRequestRequest{
 		CommonCreateRequestRequest: &router.CommonCreateRequestRequest{
-			Audience:  []string{"mario"},
-			IssuerDID: issuerDID.DID.ID,
-			IssuerKID: kid,
+			Audience:             []string{"mario"},
+			IssuerDID:            issuerDID.DID.ID,
+			VerificationMethodID: kid,
 		},
 		CredentialManifestID: credentialManifest.ID,
 	}
@@ -1129,10 +1129,10 @@ func getValidIssuanceTemplateRequest(m manifest.CredentialManifest, issuerDID *d
 	schemaID string, expiry1 time.Time, expiry2 time.Duration) *issuance.CreateIssuanceTemplateRequest {
 	return &issuance.CreateIssuanceTemplateRequest{
 		IssuanceTemplate: issuance.Template{
-			ID:                 uuid.NewString(),
-			CredentialManifest: m.ID,
-			Issuer:             issuerDID.DID.ID,
-			IssuerKID:          issuerDID.DID.VerificationMethod[0].ID,
+			ID:                   uuid.NewString(),
+			CredentialManifest:   m.ID,
+			Issuer:               issuerDID.DID.ID,
+			VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
 			Credentials: []issuance.CredentialTemplate{
 				{
 					ID:                        "drivers-license-ca",

--- a/pkg/server/server_presentation_test.go
+++ b/pkg/server/server_presentation_test.go
@@ -711,8 +711,8 @@ func TestPresentationAPI(t *testing.T) {
 func createPresentationRequest(t *testing.T, pRouter *router.PresentationRouter, definitionID string, issuerDID didsdk.Document) router.CreateRequestResponse {
 	request := router.CreateRequestRequest{
 		CommonCreateRequestRequest: &router.CommonCreateRequestRequest{
-			IssuerDID: issuerDID.ID,
-			IssuerKID: issuerDID.VerificationMethod[0].ID,
+			IssuerDID:            issuerDID.ID,
+			VerificationMethodID: issuerDID.VerificationMethod[0].ID,
 		},
 		PresentationDefinitionID: definitionID,
 	}

--- a/pkg/server/server_schema_test.go
+++ b/pkg/server/server_schema_test.go
@@ -87,7 +87,7 @@ func TestSchemaAPI(t *testing.T) {
 
 				c := newRequestContext(w, req)
 				schemaService.CreateSchema(c)
-				assert.Contains(tt, w.Body.String(), "issuerKid is a required field")
+				assert.Contains(tt, w.Body.String(), "verificationMethodId is a required field")
 
 				// reset the http recorder
 				w = httptest.NewRecorder()
@@ -99,15 +99,15 @@ func TestSchemaAPI(t *testing.T) {
 				})
 				require.NoError(t, err)
 				issuerID := issuerResp.DID.ID
-				issuerKID := issuerResp.DID.VerificationMethod[0].ID
+				verificationMethodID := issuerResp.DID.VerificationMethod[0].ID
 
 				// create the credential schema
 				schemaRequest := router.CreateSchemaRequest{
 					Name:   "test schema",
 					Schema: simpleSchema,
 					CredentialSchemaRequest: &router.CredentialSchemaRequest{
-						Issuer:    issuerID,
-						IssuerKID: issuerKID,
+						Issuer:               issuerID,
+						VerificationMethodID: verificationMethodID,
 					},
 				}
 				schemaRequestValue = newRequestValue(tt, schemaRequest)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -139,10 +139,10 @@ func newRequestContextWithURLValues(w http.ResponseWriter, req *http.Request, pa
 	return c
 }
 
-func getValidCreateManifestRequest(issuerDID, issuerKID, schemaID string) router.CreateManifestRequest {
+func getValidCreateManifestRequest(issuerDID, verificationMethodID, schemaID string) router.CreateManifestRequest {
 	return router.CreateManifestRequest{
-		IssuerDID: issuerDID,
-		IssuerKID: issuerKID,
+		IssuerDID:            issuerDID,
+		VerificationMethodID: verificationMethodID,
 		ClaimFormat: &exchange.ClaimFormat{
 			JWTVC: &exchange.JWTType{Alg: []crypto.SignatureAlgorithm{crypto.EdDSA}},
 		},

--- a/pkg/service/common/storage.go
+++ b/pkg/service/common/storage.go
@@ -10,13 +10,13 @@ import (
 )
 
 type StoredRequest struct {
-	ID          string   `json:"id"`
-	Audience    []string `json:"audience"`
-	Expiration  string   `json:"expiration"`
-	IssuerDID   string   `json:"issuerId"`
-	IssuerKID   string   `json:"issuerKid"`
-	ReferenceID string   `json:"referenceId"`
-	JWT         string   `json:"jwt"`
+	ID                   string   `json:"id"`
+	Audience             []string `json:"audience"`
+	Expiration           string   `json:"expiration"`
+	IssuerDID            string   `json:"issuerId"`
+	VerificationMethodID string   `json:"verificationMethodId"`
+	ReferenceID          string   `json:"referenceId"`
+	JWT                  string   `json:"jwt"`
 }
 
 type RequestStorage interface {

--- a/pkg/service/common/validation.go
+++ b/pkg/service/common/validation.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func ValidateVerificationMethodID(fullyQualifiedVerificationMethodID, issuerID string) error {
+	if !strings.HasPrefix(fullyQualifiedVerificationMethodID, issuerID) {
+		return errors.Errorf("issuer <%s> must be part of verification method <%s>", issuerID, fullyQualifiedVerificationMethodID)
+	}
+	return nil
+}

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -3,7 +3,9 @@ package credential
 import (
 	"fmt"
 
+	"github.com/TBD54566975/ssi-sdk/util"
 	"github.com/tbd54566975/ssi-service/internal/credential"
+	"github.com/tbd54566975/ssi-service/pkg/service/common"
 )
 
 type BatchCreateCredentialsRequest struct {
@@ -109,7 +111,7 @@ func (csr CreateCredentialRequest) hasEvidence() bool {
 	return len(csr.Evidence) != 0
 }
 
-func (csr *CreateCredentialRequest) validateEvidence() error {
+func (csr CreateCredentialRequest) validateEvidence() error {
 	for _, e := range csr.Evidence {
 		evidenceMap, ok := e.(map[string]any)
 		if !ok {
@@ -125,4 +127,11 @@ func (csr *CreateCredentialRequest) validateEvidence() error {
 	}
 
 	return nil
+}
+
+func (csr CreateCredentialRequest) IsValid() error {
+	if err := util.IsValidStruct(csr); err != nil {
+		return err
+	}
+	return common.ValidateVerificationMethodID(csr.FullyQualifiedVerificationMethodID, csr.Issuer)
 }

--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -88,6 +88,10 @@ func NewCredentialService(config config.CredentialServiceConfig, s storage.Servi
 }
 
 func (s Service) CreateCredential(ctx context.Context, request CreateCredentialRequest) (*CreateCredentialResponse, error) {
+	if err := request.IsValid(); err != nil {
+		return nil, errors.Wrap(err, "validating request")
+	}
+
 	watchKeys := make([]storage.WatchKey, 0)
 
 	var statusMetadata StatusListCredentialMetadata
@@ -238,12 +242,12 @@ func (s Service) createCredential(ctx context.Context, request CreateCredentialR
 	}
 
 	container := credint.Container{
-		ID:            credentialID,
-		IssuerKID:     request.FullyQualifiedVerificationMethodID,
-		Credential:    cred,
-		CredentialJWT: credJWT,
-		Revoked:       false,
-		Suspended:     false,
+		ID:                                 credentialID,
+		FullyQualifiedVerificationMethodID: request.FullyQualifiedVerificationMethodID,
+		Credential:                         cred,
+		CredentialJWT:                      credJWT,
+		Revoked:                            false,
+		Suspended:                          false,
 	}
 
 	credentialStorageRequest := StoreCredentialRequest{
@@ -257,19 +261,19 @@ func (s Service) createCredential(ctx context.Context, request CreateCredentialR
 }
 
 // signCredentialJWT signs a credential and returns it as a vc-jwt
-func (s Service) signCredentialJWT(ctx context.Context, issuerKID string, cred credential.VerifiableCredential) (*keyaccess.JWT, error) {
-	keyStoreID := did.FullyQualifiedVerificationMethodID(cred.IssuerID(), issuerKID)
+func (s Service) signCredentialJWT(ctx context.Context, verificationMethodID string, cred credential.VerifiableCredential) (*keyaccess.JWT, error) {
+	keyStoreID := did.FullyQualifiedVerificationMethodID(cred.IssuerID(), verificationMethodID)
 	gotKey, err := s.keyStore.GetKey(ctx, keystore.GetKeyRequest{ID: keyStoreID})
 	if err != nil {
-		return nil, sdkutil.LoggingErrorMsgf(err, "getting key for signing credential<%s>", issuerKID)
+		return nil, sdkutil.LoggingErrorMsgf(err, "getting key for signing credential<%s>", verificationMethodID)
 	}
 	if gotKey.Controller != cred.Issuer.(string) {
-		return nil, sdkutil.LoggingNewErrorf("key controller<%s> does not match credential issuer<%s> for key<%s>", gotKey.Controller, cred.Issuer, issuerKID)
+		return nil, sdkutil.LoggingNewErrorf("key controller<%s> does not match credential issuer<%s> for key<%s>", gotKey.Controller, cred.Issuer, verificationMethodID)
 	}
 	if gotKey.Revoked {
 		return nil, sdkutil.LoggingNewErrorf("cannot use revoked key<%s>", gotKey.ID)
 	}
-	keyAccess, err := keyaccess.NewJWKKeyAccess(issuerKID, gotKey.ID, gotKey.Key)
+	keyAccess, err := keyaccess.NewJWKKeyAccess(verificationMethodID, gotKey.ID, gotKey.Key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating key access for signing credential with key<%s>", gotKey.ID)
 	}
@@ -569,12 +573,12 @@ func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, tx sto
 func updateCredentialStatus(ctx context.Context, tx storage.Tx, s Service, gotCred *StoredCredential, request UpdateCredentialStatusRequest, slcMetadata StatusListCredentialMetadata) (*credint.Container, error) {
 	// store the credential with updated status
 	container := credint.Container{
-		ID:            gotCred.LocalCredentialID,
-		IssuerKID:     gotCred.IssuerKID,
-		Credential:    gotCred.Credential,
-		CredentialJWT: gotCred.CredentialJWT,
-		Revoked:       request.Revoked,
-		Suspended:     request.Suspended,
+		ID:                                 gotCred.LocalCredentialID,
+		FullyQualifiedVerificationMethodID: gotCred.FullyQualifiedVerificationMethodID,
+		Credential:                         gotCred.Credential,
+		CredentialJWT:                      gotCred.CredentialJWT,
+		Revoked:                            request.Revoked,
+		Suspended:                          request.Suspended,
 	}
 
 	storageRequest := StoreCredentialRequest{
@@ -633,17 +637,17 @@ func updateCredentialStatus(ctx context.Context, tx storage.Tx, s Service, gotCr
 
 	generatedStatusListCredential.CredentialSchema = gotCred.Credential.CredentialSchema
 
-	statusListCredJWT, err := s.signCredentialJWT(ctx, gotCred.IssuerKID, *generatedStatusListCredential)
+	statusListCredJWT, err := s.signCredentialJWT(ctx, gotCred.FullyQualifiedVerificationMethodID, *generatedStatusListCredential)
 	if err != nil {
 		return nil, sdkutil.LoggingErrorMsg(err, "could not sign status list credential")
 	}
 
 	// store the status list credential
 	statusListContainer := credint.Container{
-		ID:            statusListCredentialID,
-		IssuerKID:     gotCred.IssuerKID,
-		Credential:    generatedStatusListCredential,
-		CredentialJWT: statusListCredJWT,
+		ID:                                 statusListCredentialID,
+		FullyQualifiedVerificationMethodID: gotCred.FullyQualifiedVerificationMethodID,
+		Credential:                         generatedStatusListCredential,
+		CredentialJWT:                      statusListCredJWT,
 	}
 
 	storageRequest = StoreCredentialRequest{

--- a/pkg/service/credential/status.go
+++ b/pkg/service/credential/status.go
@@ -18,7 +18,7 @@ import (
 func (s Service) createStatusListEntryForCredential(ctx context.Context, credID string, request CreateCredentialRequest,
 	tx storage.Tx, statusMetadata StatusListCredentialMetadata) (*statussdk.StatusList2021Entry, error) {
 	issuerID := request.Issuer
-	issuerKID := request.FullyQualifiedVerificationMethodID
+	fullyQualifiedVerificationMethodID := request.FullyQualifiedVerificationMethodID
 	schemaID := request.SchemaID
 
 	statusPurpose := statussdk.StatusRevocation
@@ -37,7 +37,7 @@ func (s Service) createStatusListEntryForCredential(ctx context.Context, credID 
 
 	if statusListCredential == nil {
 		// creates status list credential with random index
-		randomIndex, statusCred, err = s.createStatusListCredential(ctx, tx, statusPurpose, issuerID, issuerKID, statusMetadata)
+		randomIndex, statusCred, err = s.createStatusListCredential(ctx, tx, statusPurpose, issuerID, fullyQualifiedVerificationMethodID, statusMetadata)
 		if err != nil {
 			return nil, sdkutil.LoggingErrorMsgf(err, "problem with getting status list credential")
 		}
@@ -65,7 +65,7 @@ func (s Service) createStatusListEntryForCredential(ctx context.Context, credID 
 	}, nil
 }
 
-func (s Service) createStatusListCredential(ctx context.Context, tx storage.Tx, statusPurpose statussdk.StatusPurpose, issuerID, issuerKID string, slcMetadata StatusListCredentialMetadata) (int, *credential.VerifiableCredential, error) {
+func (s Service) createStatusListCredential(ctx context.Context, tx storage.Tx, statusPurpose statussdk.StatusPurpose, issuerID, fullyQualifiedVerificationMethodID string, slcMetadata StatusListCredentialMetadata) (int, *credential.VerifiableCredential, error) {
 	statusListID := uuid.NewString()
 	statusListURI := fmt.Sprintf("%s/status/%s", s.config.ServiceEndpoint, statusListID)
 
@@ -74,16 +74,16 @@ func (s Service) createStatusListCredential(ctx context.Context, tx storage.Tx, 
 		return -1, nil, sdkutil.LoggingErrorMsg(err, "could not generate status list")
 	}
 
-	statusListCredJWT, err := s.signCredentialJWT(ctx, issuerKID, *generatedStatusListCredential)
+	statusListCredJWT, err := s.signCredentialJWT(ctx, fullyQualifiedVerificationMethodID, *generatedStatusListCredential)
 	if err != nil {
 		return -1, nil, sdkutil.LoggingErrorMsg(err, "could not sign status list credential")
 	}
 
 	statusListContainer := credint.Container{
-		ID:            statusListID,
-		IssuerKID:     issuerKID,
-		Credential:    generatedStatusListCredential,
-		CredentialJWT: statusListCredJWT,
+		ID:                                 statusListID,
+		FullyQualifiedVerificationMethodID: fullyQualifiedVerificationMethodID,
+		Credential:                         generatedStatusListCredential,
+		CredentialJWT:                      statusListCredJWT,
 	}
 
 	statusListStorageRequest := StoreCredentialRequest{

--- a/pkg/service/credential/storage.go
+++ b/pkg/service/credential/storage.go
@@ -35,13 +35,13 @@ type StoredCredential struct {
 	Credential    *credential.VerifiableCredential `json:"credential,omitempty"`
 	CredentialJWT *keyaccess.JWT                   `json:"token,omitempty"`
 
-	Issuer       string `json:"issuer"`
-	IssuerKID    string `json:"issuerKid"`
-	Subject      string `json:"subject"`
-	Schema       string `json:"schema"`
-	IssuanceDate string `json:"issuanceDate"`
-	Revoked      bool   `json:"revoked"`
-	Suspended    bool   `json:"suspended"`
+	Issuer                             string `json:"issuer"`
+	FullyQualifiedVerificationMethodID string `json:"fullyQualifiedVerificationMethodId"`
+	Subject                            string `json:"subject"`
+	Schema                             string `json:"schema"`
+	IssuanceDate                       string `json:"issuanceDate"`
+	Revoked                            bool   `json:"revoked"`
+	Suspended                          bool   `json:"suspended"`
 }
 
 type WriteContext struct {
@@ -304,17 +304,17 @@ func buildStoredCredential(request StoreCredentialRequest) (*StoredCredential, e
 		schema = cred.CredentialSchema.ID
 	}
 	return &StoredCredential{
-		Key:               createPrefixKey(credID, issuer, subject, schema),
-		LocalCredentialID: credID,
-		Credential:        cred,
-		CredentialJWT:     request.CredentialJWT,
-		Issuer:            issuer,
-		IssuerKID:         request.IssuerKID,
-		Subject:           subject,
-		Schema:            schema,
-		IssuanceDate:      cred.IssuanceDate,
-		Revoked:           request.Revoked,
-		Suspended:         request.Suspended,
+		Key:                                createPrefixKey(credID, issuer, subject, schema),
+		LocalCredentialID:                  credID,
+		Credential:                         cred,
+		CredentialJWT:                      request.CredentialJWT,
+		Issuer:                             issuer,
+		FullyQualifiedVerificationMethodID: request.FullyQualifiedVerificationMethodID,
+		Subject:                            subject,
+		Schema:                             schema,
+		IssuanceDate:                       cred.IssuanceDate,
+		Revoked:                            request.Revoked,
+		Suspended:                          request.Suspended,
 	}, nil
 }
 

--- a/pkg/service/manifest/model/model.go
+++ b/pkg/service/manifest/model/model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TBD54566975/ssi-sdk/credential/exchange"
 	manifestsdk "github.com/TBD54566975/ssi-sdk/credential/manifest"
+	sdkutil "github.com/TBD54566975/ssi-sdk/util"
 	"github.com/tbd54566975/ssi-service/pkg/service/common"
 
 	cred "github.com/tbd54566975/ssi-service/internal/credential"
@@ -23,6 +24,13 @@ type CreateManifestRequest struct {
 	OutputDescriptors                  []manifestsdk.OutputDescriptor `json:"outputDescriptors" validate:"required,dive"`
 	ClaimFormat                        *exchange.ClaimFormat          `json:"format" validate:"required,dive"`
 	PresentationDefinitionRef          *PresentationDefinitionRef     `json:"presentationDefinitionRef,omitempty" validate:"omitempty,dive"`
+}
+
+func (r CreateManifestRequest) IsValid() error {
+	if err := sdkutil.IsValidStruct(r); err != nil {
+		return err
+	}
+	return common.ValidateVerificationMethodID(r.FullyQualifiedVerificationMethodID, r.IssuerDID)
 }
 
 type CreateManifestResponse struct {

--- a/pkg/service/manifest/storage/storage.go
+++ b/pkg/service/manifest/storage/storage.go
@@ -25,10 +25,10 @@ const (
 )
 
 type StoredManifest struct {
-	ID        string                      `json:"id"`
-	IssuerDID string                      `json:"issuerDid"`
-	IssuerKID string                      `json:"issuerKid"`
-	Manifest  manifest.CredentialManifest `json:"manifest"`
+	ID                                 string                      `json:"id"`
+	IssuerDID                          string                      `json:"issuerDid"`
+	FullyQualifiedVerificationMethodID string                      `json:"fullyQualifiedVerificationMethodId"`
+	Manifest                           manifest.CredentialManifest `json:"manifest"`
 }
 
 type StoredApplication struct {

--- a/pkg/service/presentation/storage/storage.go
+++ b/pkg/service/presentation/storage/storage.go
@@ -15,8 +15,6 @@ import (
 type StoredDefinition struct {
 	ID                     string                          `json:"id"`
 	PresentationDefinition exchange.PresentationDefinition `json:"presentationDefinition"`
-	Author                 string                          `json:"issuerID"`
-	AuthorKID              string                          `json:"issuerKid"`
 }
 
 type Storage interface {
@@ -28,7 +26,6 @@ type DefinitionStorage interface {
 	StoreDefinition(ctx context.Context, presentation StoredDefinition) error
 	GetDefinition(ctx context.Context, id string) (*StoredDefinition, error)
 	DeleteDefinition(ctx context.Context, id string) error
-	// TODO: Make this consistent across API boundaries https://github.com/TBD54566975/ssi-service/issues/449
 	ListDefinitions(ctx context.Context) ([]StoredDefinition, error)
 }
 

--- a/pkg/service/schema/model.go
+++ b/pkg/service/schema/model.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"github.com/TBD54566975/ssi-sdk/credential/schema"
 	"github.com/TBD54566975/ssi-sdk/util"
+	"github.com/tbd54566975/ssi-service/pkg/service/common"
 
 	"github.com/tbd54566975/ssi-service/internal/keyaccess"
 )
@@ -13,17 +14,23 @@ type CreateSchemaRequest struct {
 	Schema      schema.JSONSchema `json:"schema" validate:"required"`
 
 	// If both are present the schema will be signed by the issuer's private key with the specified KID
-	Issuer    string `json:"issuer,omitempty"`
-	IssuerKID string `json:"issuerKid,omitempty"`
+	Issuer                             string `json:"issuer,omitempty"`
+	FullyQualifiedVerificationMethodID string `json:"fullyQualifiedVerificationMethodId,omitempty"`
 }
 
 // IsCredentialSchemaRequest returns true if the request is for a credential schema
 func (csr CreateSchemaRequest) IsCredentialSchemaRequest() bool {
-	return csr.Issuer != "" && csr.IssuerKID != ""
+	return csr.Issuer != "" && csr.FullyQualifiedVerificationMethodID != ""
 }
 
-func (csr CreateSchemaRequest) IsValid() bool {
-	return util.IsValidStruct(csr) == nil
+func (csr CreateSchemaRequest) IsValid() error {
+	if err := util.IsValidStruct(csr); err != nil {
+		return err
+	}
+	if csr.FullyQualifiedVerificationMethodID != "" && csr.Issuer != "" {
+		return common.ValidateVerificationMethodID(csr.FullyQualifiedVerificationMethodID, csr.Issuer)
+	}
+	return nil
 }
 
 type CreateSchemaResponse struct {


### PR DESCRIPTION
# Overview
This makes clear how it related to the fully resolved DID document

# Description
`IssuerKID` has been confusing. VerificationMethodID makes explicit what the relationship with the DID (which is the issuer) is. 

# How Has This Been Tested?
Simple refactoring. No change in the substance of the tests.

