### PR TITLE
Added batch update for statuses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,8 +146,10 @@ func (d *DIDServiceConfig) IsEmpty() bool {
 }
 
 type CredentialServiceConfig struct {
-	// BatchCreateMaxItems set's the maximum amount that can be.
+	// BatchCreateMaxItems set's the maximum amount of credentials that can be created in a single request.
 	BatchCreateMaxItems int `toml:"batch_create_max_items" conf:"default:100"`
+	// BatchUpdateStatusMaxItems set's the maximum amount of credentials statuses that can be updated in a single request.
+	BatchUpdateStatusMaxItems int `toml:"batch_update_status_max_items" conf:"default:100"`
 
 	// TODO(gabe) supported key and signature types
 }

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -41,6 +41,7 @@ batch_create_max_items = 100
 
 [services.credential]
 batch_create_max_items = 100
+batch_update_status_max_items = 100
 
 [services.webhook]
 webhook_timeout = "10s"

--- a/config/kitchensink.toml
+++ b/config/kitchensink.toml
@@ -51,6 +51,7 @@ batch_create_max_items = 100
 
 [services.credential]
 batch_create_max_items = 100
+batch_update_status_max_items = 100
 
 [services.webhook]
 webhook_timeout = "10s"

--- a/config/prod.toml
+++ b/config/prod.toml
@@ -51,6 +51,7 @@ batch_create_max_items = 100
 
 [services.credential]
 batch_create_max_items = 100
+batch_update_status_max_items = 100
 
 [services.webhook]
 webhook_timeout = "10s"

--- a/config/test.toml
+++ b/config/test.toml
@@ -53,6 +53,7 @@ batch_create_max_items = 100
 
 [services.credential]
 batch_create_max_items = 100
+batch_update_status_max_items = 100
 
 [services.webhook]
 webhook_timeout = "10s"

--- a/doc/howto/didweb.md
+++ b/doc/howto/didweb.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The [did:web Method Specification)](https://w3c-ccg.github.io/did-method-web/) describes a DID method that uses an existing web domain to host and establish trust for a DID Document.
+The [did:web Method Specification](https://w3c-ccg.github.io/did-method-web/) describes a DID method that uses an existing web domain to host and establish trust for a DID Document.
 
 It relies on the controller of an existing domain to host a custom file with the contents of the DID Document they want to expose. The SSI Service facilitates creation of a `did:web`, which you then must update on the domain you control.
 

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -566,7 +566,7 @@ definitions:
   github_com_tbd54566975_ssi-service_pkg_service_credential.Status:
     properties:
       id:
-        description: ID of the credentials who's status this object represents.
+        description: ID of the credentials whose status this object represents.
         type: string
       revoked:
         type: boolean
@@ -1986,6 +1986,8 @@ definitions:
         type: boolean
       suspended:
         type: boolean
+    required:
+    - id
     type: object
   pkg_server_router.StateChange:
     properties:

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -563,6 +563,19 @@ definitions:
         description: Whether this credential is currently suspended.
         type: boolean
     type: object
+  github_com_tbd54566975_ssi-service_pkg_service_credential.Status:
+    properties:
+      id:
+        description: ID of the credentials who's status this object represents.
+        type: string
+      revoked:
+        type: boolean
+      suspended:
+        type: boolean
+    required:
+    - revoked
+    - suspended
+    type: object
   github_com_tbd54566975_ssi-service_pkg_service_did.CreateIONDIDOptions:
     properties:
       jwsPublicKeys:
@@ -1086,6 +1099,24 @@ definitions:
         description: The DID documents created.
         items:
           $ref: '#/definitions/did.Document'
+        type: array
+    type: object
+  pkg_server_router.BatchUpdateCredentialStatusRequest:
+    properties:
+      requests:
+        description: Required. The list of update credential requests. Cannot be more
+          than the config value in `services.credentials.batch_update_status_max_items`.
+        items:
+          $ref: '#/definitions/pkg_server_router.SingleUpdateCredentialStatusRequest'
+        type: array
+    required:
+    - requests
+    type: object
+  pkg_server_router.BatchUpdateCredentialStatusResponse:
+    properties:
+      credentialStatuses:
+        items:
+          $ref: '#/definitions/github_com_tbd54566975_ssi-service_pkg_service_credential.Status'
         type: array
     type: object
   pkg_server_router.CreateCredentialRequest:
@@ -1943,6 +1974,19 @@ definitions:
       id:
         type: string
     type: object
+  pkg_server_router.SingleUpdateCredentialStatusRequest:
+    properties:
+      id:
+        description: ID of the credential who's status should be updated.
+        type: string
+      revoked:
+        description: |-
+          The new revoked status of this credential. The status will be saved in the encodedList of the StatusList2021
+          credential associated with this VC.
+        type: boolean
+      suspended:
+        type: boolean
+    type: object
   pkg_server_router.StateChange:
     properties:
       publicKeyIdsToRemove:
@@ -2610,6 +2654,36 @@ paths:
           schema:
             type: string
       summary: Get a Credential Status List
+      tags:
+      - Credentials
+  /v1/credentials/status/batch:
+    put:
+      consumes:
+      - application/json
+      description: Updates the status all a batch of Verifiable Credentials.
+      parameters:
+      - description: request body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/pkg_server_router.BatchUpdateCredentialStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/pkg_server_router.BatchUpdateCredentialStatusResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Batch Update a Verifiable Credential's status
       tags:
       - Credentials
   /v1/credentials/verification:

--- a/integration/common.go
+++ b/integration/common.go
@@ -242,6 +242,29 @@ func BatchCreateVerifiableCredentials(credentialInput batchCredInputParams) (str
 	return output, nil
 }
 
+type batchUpdateStatusInputParams struct {
+	CredentialID0 string
+	Suspended0    bool
+	CredentialID1 string
+	Revoked1      bool
+}
+
+func BatchUpdateVerifiableCredentialStatuses(updateStatusInput batchUpdateStatusInputParams) (string, error) {
+	logrus.Println("\n\nCreate a verifiable credential")
+
+	updateStatusesJSON, err := resolveTemplate(updateStatusInput, "batch-update-credential-statuses-input.json")
+	if err != nil {
+		return "", err
+	}
+
+	output, err := put(endpoint+version+"credentials/status/batch", updateStatusesJSON)
+	if err != nil {
+		return "", errors.Wrap(err, "error writing batch update status")
+	}
+
+	return output, nil
+}
+
 func BatchCreate100VerifiableCredentials(credentialInput credInputParams) (string, error) {
 	logrus.Println("\n\nCreate a verifiable credential")
 

--- a/integration/testdata/batch-update-credential-statuses-input.json
+++ b/integration/testdata/batch-update-credential-statuses-input.json
@@ -1,0 +1,12 @@
+{
+  "requests": [
+    {
+      "id": "{{.CredentialID0}}",
+      "suspended": {{.Suspended0}}
+    },
+    {
+      "id": "{{.CredentialID1}}",
+      "revoked": {{.Revoked1}}
+    }
+  ]
+}

--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -339,6 +339,72 @@ type UpdateCredentialStatusResponse struct {
 	Suspended bool `json:"suspended"`
 }
 
+type SingleUpdateCredentialStatusRequest struct {
+	// ID of the credential who's status should be updated.
+	ID string `json:"id"`
+	UpdateCredentialStatusRequest
+}
+
+type BatchUpdateCredentialStatusRequest struct {
+	// Required. The list of update credential requests. Cannot be more than the config value in `services.credentials.batch_update_status_max_items`.
+	Requests []SingleUpdateCredentialStatusRequest `json:"requests" maxItems:"100" validate:"required,dive"`
+}
+
+func (r BatchUpdateCredentialStatusRequest) toServiceRequest() *credential.BatchUpdateCredentialStatusRequest {
+	var req credential.BatchUpdateCredentialStatusRequest
+	for _, routerReq := range r.Requests {
+		serviceReq := routerReq.toServiceRequest(routerReq.ID)
+		req.Requests = append(req.Requests, serviceReq)
+	}
+	return &req
+}
+
+type BatchUpdateCredentialStatusResponse struct {
+	CredentialStatuses []credential.Status `json:"credentialStatuses"`
+}
+
+// BatchUpdateCredentialStatus godoc
+//
+//	@Summary		Batch Update a Verifiable Credential's status
+//	@Description	Updates the status all a batch of Verifiable Credentials.
+//	@Tags			Credentials
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		BatchUpdateCredentialStatusRequest	true	"request body"
+//	@Success		201		{object}	BatchUpdateCredentialStatusResponse
+//	@Failure		400		{string}	string	"Bad request"
+//	@Failure		500		{string}	string	"Internal server error"
+//	@Router			/v1/credentials/status/batch [put]
+func (cr CredentialRouter) BatchUpdateCredentialStatus(c *gin.Context) {
+	var batchRequest BatchUpdateCredentialStatusRequest
+	invalidCreateCredentialRequest := "invalid batch update credential request"
+	if err := framework.Decode(c.Request, &batchRequest); err != nil {
+		errMsg := invalidCreateCredentialRequest
+		framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusBadRequest)
+		return
+	}
+
+	batchUpdateMaxItems := cr.service.Config().BatchUpdateStatusMaxItems
+	if len(batchRequest.Requests) > batchUpdateMaxItems {
+		framework.LoggingRespondErrMsg(c, fmt.Sprintf("max number of requests is %d", batchUpdateMaxItems), http.StatusBadRequest)
+		return
+	}
+
+	req := batchRequest.toServiceRequest()
+	batchUpdateResponse, err := cr.service.BatchUpdateCredentialStatus(c, *req)
+
+	if err != nil {
+		errMsg := "could not update credentials"
+		framework.LoggingRespondErrWithMsg(c, err, errMsg, http.StatusInternalServerError)
+		return
+	}
+
+	var resp BatchUpdateCredentialStatusResponse
+	resp.CredentialStatuses = append(resp.CredentialStatuses, batchUpdateResponse.CredentialStatuses...)
+
+	framework.Respond(c, resp, http.StatusOK)
+}
+
 // UpdateCredentialStatus godoc
 //
 //	@Summary		Update a Verifiable Credential's status

--- a/pkg/server/router/credential.go
+++ b/pkg/server/router/credential.go
@@ -341,7 +341,7 @@ type UpdateCredentialStatusResponse struct {
 
 type SingleUpdateCredentialStatusRequest struct {
 	// ID of the credential who's status should be updated.
-	ID string `json:"id"`
+	ID string `json:"id" validate:"required"`
 	UpdateCredentialStatusRequest
 }
 
@@ -350,13 +350,13 @@ type BatchUpdateCredentialStatusRequest struct {
 	Requests []SingleUpdateCredentialStatusRequest `json:"requests" maxItems:"100" validate:"required,dive"`
 }
 
-func (r BatchUpdateCredentialStatusRequest) toServiceRequest() *credential.BatchUpdateCredentialStatusRequest {
+func (r BatchUpdateCredentialStatusRequest) toServiceRequest() credential.BatchUpdateCredentialStatusRequest {
 	var req credential.BatchUpdateCredentialStatusRequest
 	for _, routerReq := range r.Requests {
 		serviceReq := routerReq.toServiceRequest(routerReq.ID)
 		req.Requests = append(req.Requests, serviceReq)
 	}
-	return &req
+	return req
 }
 
 type BatchUpdateCredentialStatusResponse struct {
@@ -391,7 +391,7 @@ func (cr CredentialRouter) BatchUpdateCredentialStatus(c *gin.Context) {
 	}
 
 	req := batchRequest.toServiceRequest()
-	batchUpdateResponse, err := cr.service.BatchUpdateCredentialStatus(c, *req)
+	batchUpdateResponse, err := cr.service.BatchUpdateCredentialStatus(c, req)
 
 	if err != nil {
 		errMsg := "could not update credentials"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,6 +44,8 @@ const (
 	VerificationPath        = "/verification"
 	WebhookPrefix           = "/webhooks"
 	DIDConfigurationsPrefix = "/did-configurations"
+
+	batchSuffix = "/batch"
 )
 
 // SSIServer exposes all dependencies needed to run a http server and all its services
@@ -209,7 +211,7 @@ func CredentialAPI(rg *gin.RouterGroup, service svcframework.Service, webhookSer
 	// Credentials
 	credentialAPI := rg.Group(CredentialsPrefix)
 	credentialAPI.PUT("", middleware.Webhook(webhookService, webhook.Credential, webhook.Create), credRouter.CreateCredential)
-	credentialAPI.PUT("/batch", middleware.Webhook(webhookService, webhook.Credential, webhook.BatchCreate), credRouter.BatchCreateCredentials)
+	credentialAPI.PUT(batchSuffix, middleware.Webhook(webhookService, webhook.Credential, webhook.BatchCreate), credRouter.BatchCreateCredentials)
 	credentialAPI.GET("", credRouter.ListCredentials)
 	credentialAPI.GET("/:id", credRouter.GetCredential)
 	credentialAPI.PUT(VerificationPath, credRouter.VerifyCredential)
@@ -218,7 +220,7 @@ func CredentialAPI(rg *gin.RouterGroup, service svcframework.Service, webhookSer
 	// Credential Status
 	credentialAPI.GET("/:id"+StatusPrefix, credRouter.GetCredentialStatus)
 	credentialAPI.PUT("/:id"+StatusPrefix, credRouter.UpdateCredentialStatus)
-	credentialAPI.PUT(StatusPrefix+"/batch", credRouter.BatchUpdateCredentialStatus)
+	credentialAPI.PUT(StatusPrefix+batchSuffix, credRouter.BatchUpdateCredentialStatus)
 	credentialAPI.GET(StatusPrefix+"/:id", credRouter.GetCredentialStatusList)
 	return
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -218,6 +218,7 @@ func CredentialAPI(rg *gin.RouterGroup, service svcframework.Service, webhookSer
 	// Credential Status
 	credentialAPI.GET("/:id"+StatusPrefix, credRouter.GetCredentialStatus)
 	credentialAPI.PUT("/:id"+StatusPrefix, credRouter.UpdateCredentialStatus)
+	credentialAPI.PUT(StatusPrefix+"/batch", credRouter.BatchUpdateCredentialStatus)
 	credentialAPI.GET(StatusPrefix+"/:id", credRouter.GetCredentialStatusList)
 	return
 }

--- a/pkg/server/server_credential_test.go
+++ b/pkg/server/server_credential_test.go
@@ -31,6 +31,109 @@ func TestCredentialAPI(t *testing.T) {
 
 	for _, test := range testutil.TestDatabases {
 		t.Run(test.Name, func(tt *testing.T) {
+			tt.Run("Batch Update Credential Status", func(ttt *testing.T) {
+				db := test.ServiceStorage(ttt)
+				require.NotEmpty(ttt, db)
+
+				keyStoreService, _ := testKeyStoreService(ttt, db)
+				didService, _ := testDIDService(ttt, db, keyStoreService, nil)
+				schemaService := testSchemaService(ttt, db, keyStoreService, didService)
+				credRouter := testCredentialRouter(ttt, db, keyStoreService, didService, schemaService)
+
+				issuerDID, err := didService.CreateDIDByMethod(context.Background(), did.CreateDIDRequest{
+					Method:  didsdk.KeyMethod,
+					KeyType: crypto.Ed25519,
+				})
+				assert.NoError(ttt, err)
+				assert.NotEmpty(ttt, issuerDID)
+
+				batchCreateCredentialsRequest := router.BatchCreateCredentialsRequest{
+					Requests: []router.CreateCredentialRequest{
+						{
+							Issuer:               issuerDID.DID.ID,
+							VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+							Subject:              "did:abc:456",
+							Data: map[string]any{
+								"firstName": "Jack",
+								"lastName":  "Dorsey",
+							},
+							Suspendable: true,
+						},
+						{
+							Issuer:               issuerDID.DID.ID,
+							VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+							Subject:              "did:abc:789",
+							Data: map[string]any{
+								"firstName": "Lemony",
+								"lastName":  "Snickets",
+							},
+							Revocable: true,
+						},
+						{
+							Issuer:               issuerDID.DID.ID,
+							VerificationMethodID: issuerDID.DID.VerificationMethod[0].ID,
+							Subject:              "did:abc:abc",
+							Data: map[string]any{
+								"firstName": "Curtis",
+								"lastName":  "Fictious",
+							},
+							Suspendable: true,
+						},
+					},
+				}
+				requestValue := newRequestValue(ttt, batchCreateCredentialsRequest)
+				req := httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/credentials/batch", requestValue)
+				w := httptest.NewRecorder()
+				c := newRequestContext(w, req)
+				credRouter.BatchCreateCredentials(c)
+				assert.True(ttt, util.Is2xxResponse(w.Code))
+
+				var resp router.BatchCreateCredentialsResponse
+				err = json.NewDecoder(w.Body).Decode(&resp)
+				assert.NoError(ttt, err)
+
+				assert.Len(ttt, resp.Credentials, 3)
+
+				// Now we got to updates
+				updateCredStatusRequest := router.BatchUpdateCredentialStatusRequest{
+					Requests: []router.SingleUpdateCredentialStatusRequest{
+						{
+							ID: idFromURI(resp.Credentials[0].ID),
+							UpdateCredentialStatusRequest: router.UpdateCredentialStatusRequest{
+								Suspended: true,
+							},
+						},
+						{
+							ID: idFromURI(resp.Credentials[1].ID),
+							UpdateCredentialStatusRequest: router.UpdateCredentialStatusRequest{
+								Revoked: true,
+							},
+						},
+						{
+							ID: idFromURI(resp.Credentials[2].ID),
+							UpdateCredentialStatusRequest: router.UpdateCredentialStatusRequest{
+								Suspended: true,
+							},
+						},
+					},
+				}
+
+				requestValue = newRequestValue(ttt, updateCredStatusRequest)
+				req = httptest.NewRequest(http.MethodPut, "https://ssi-service.com/v1/credentials/status/batch", requestValue)
+				w = httptest.NewRecorder()
+				c = newRequestContext(w, req)
+				credRouter.BatchUpdateCredentialStatus(c)
+				assert.True(ttt, util.Is2xxResponse(w.Code))
+
+				var credStatusUpdateResponse router.BatchUpdateCredentialStatusResponse
+				err = json.NewDecoder(w.Body).Decode(&credStatusUpdateResponse)
+				assert.NoError(ttt, err)
+
+				assert.Len(ttt, credStatusUpdateResponse.CredentialStatuses, 3)
+				assert.True(ttt, credStatusUpdateResponse.CredentialStatuses[0].Suspended)
+				assert.True(ttt, credStatusUpdateResponse.CredentialStatuses[1].Revoked)
+				assert.True(ttt, credStatusUpdateResponse.CredentialStatuses[2].Suspended)
+			})
 
 			tt.Run("Batch Create Credentials", func(ttt *testing.T) {
 				db := test.ServiceStorage(ttt)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -282,7 +282,7 @@ func testSchemaRouter(t *testing.T, bolt storage.ServiceStorage, keyStore *keyst
 }
 
 func testCredentialService(t *testing.T, db storage.ServiceStorage, keyStore *keystore.Service, did *did.Service, schema *schema.Service) *credential.Service {
-	serviceConfig := config.CredentialServiceConfig{BatchCreateMaxItems: 1000}
+	serviceConfig := config.CredentialServiceConfig{BatchCreateMaxItems: 1000, BatchUpdateStatusMaxItems: 10}
 
 	// create a credential service
 	credentialService, err := credential.NewCredentialService(serviceConfig, db, keyStore, did.GetResolver(), schema)

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -85,8 +85,22 @@ type UpdateCredentialStatusRequest struct {
 }
 
 type UpdateCredentialStatusResponse struct {
-	Revoked   bool `json:"revoked" validate:"required"`
-	Suspended bool `json:"suspended" validate:"required"`
+	Status
+}
+
+type Status struct {
+	// ID of the credentials who's status this object represents.
+	ID        string `json:"id,omitempty"`
+	Revoked   bool   `json:"revoked" validate:"required"`
+	Suspended bool   `json:"suspended" validate:"required"`
+}
+
+type BatchUpdateCredentialStatusRequest struct {
+	Requests []UpdateCredentialStatusRequest `json:"requests"`
+}
+
+type BatchUpdateCredentialStatusResponse struct {
+	CredentialStatuses []Status `json:"credentialStatuses"`
 }
 
 type GetCredentialStatusListRequest struct {

--- a/pkg/service/credential/model.go
+++ b/pkg/service/credential/model.go
@@ -89,7 +89,7 @@ type UpdateCredentialStatusResponse struct {
 }
 
 type Status struct {
-	// ID of the credentials who's status this object represents.
+	// ID of the credentials whose status this object represents.
 	ID        string `json:"id,omitempty"`
 	Revoked   bool   `json:"revoked" validate:"required"`
 	Suspended bool   `json:"suspended" validate:"required"`

--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -425,34 +425,14 @@ func (s Service) GetCredentialStatusList(ctx context.Context, request GetCredent
 }
 
 func (s Service) UpdateCredentialStatus(ctx context.Context, request UpdateCredentialStatusRequest) (*UpdateCredentialStatusResponse, error) {
-	gotCred, err := s.storage.GetCredential(ctx, request.ID)
+
+	statusListCredentialWatchKey, err := s.statusListCredentialWatchKey(ctx, request.ID)
 	if err != nil {
-		return nil, sdkutil.LoggingErrorMsgf(err, "could not get credential: %s", request.ID)
+		return nil, err
 	}
 
-	if gotCred.Credential.CredentialStatus == nil {
-		return nil, sdkutil.LoggingNewErrorf("credential %q has no credentialStatus field", gotCred.LocalCredentialID)
-	}
-
-	statusPurpose := gotCred.Credential.CredentialStatus.(map[string]any)["statusPurpose"].(string)
-	if len(statusPurpose) == 0 {
-		return nil, sdkutil.LoggingNewErrorf("status purpose could not be derived from credential status")
-	}
-
-	statusListCredential, err := s.storage.GetStatusListCredentialKeyData(ctx, gotCred.Issuer, gotCred.Schema, statussdk.StatusPurpose(statusPurpose))
-	if err != nil {
-		return nil, errors.Wrap(err, "getting status list watch key uuid data")
-	}
-
-	if statusListCredential == nil {
-		return nil, errors.Wrap(err, "status list credential should exist in order to update")
-	}
-
-	statusListCredentialWatchKey := s.storage.GetStatusListCredentialWatchKey(gotCred.Issuer, gotCred.Schema, statusPurpose)
-
-	slcMetadata := StatusListCredentialMetadata{statusListCredentialWatchKey: statusListCredentialWatchKey}
-
-	watchKeys := []storage.WatchKey{statusListCredentialWatchKey}
+	slcMetadata := StatusListCredentialMetadata{statusListCredentialWatchKey: *statusListCredentialWatchKey}
+	watchKeys := []storage.WatchKey{*statusListCredentialWatchKey}
 	returnFunc := s.updateCredentialStatusFunc(request, slcMetadata)
 
 	returnValue, err := s.storage.db.Execute(ctx, returnFunc, watchKeys)
@@ -492,7 +472,10 @@ func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, tx sto
 	// if the request is the same as what the current credential is there is no action
 	if gotCred.Revoked == request.Revoked && gotCred.Suspended == request.Suspended {
 		logrus.Warn("request and credential have same status, no action is needed")
-		response := UpdateCredentialStatusResponse{Revoked: gotCred.Revoked, Suspended: gotCred.Suspended}
+		response := UpdateCredentialStatusResponse{Status{
+			Revoked:   gotCred.Revoked,
+			Suspended: gotCred.Suspended,
+		}}
 		return &response, nil
 	}
 
@@ -501,7 +484,7 @@ func (s Service) updateCredentialStatusBusinessLogic(ctx context.Context, tx sto
 		return nil, sdkutil.LoggingErrorMsg(err, "updating credential")
 	}
 
-	response := UpdateCredentialStatusResponse{Revoked: container.Revoked, Suspended: container.Suspended}
+	response := UpdateCredentialStatusResponse{Status{Revoked: container.Revoked, Suspended: container.Suspended}}
 	return &response, nil
 }
 
@@ -674,4 +657,72 @@ func (s Service) BatchCreateCredentials(ctx context.Context, batchRequest BatchC
 	}
 
 	return credResponse, nil
+}
+
+func (s Service) BatchUpdateCredentialStatus(ctx context.Context, batchRequest BatchUpdateCredentialStatusRequest) (*BatchUpdateCredentialStatusResponse, error) {
+	watchKeys := make([]storage.WatchKey, 0, len(batchRequest.Requests))
+	updateFuncs := make([]storage.BusinessLogicFunc, 0, len(batchRequest.Requests))
+	for _, request := range batchRequest.Requests {
+		statusListCredentialWatchKey, err := s.statusListCredentialWatchKey(ctx, request.ID)
+		if err != nil {
+			return nil, err
+		}
+		watchKeys = append(watchKeys, *statusListCredentialWatchKey)
+
+		slcMetadata := StatusListCredentialMetadata{statusListCredentialWatchKey: *statusListCredentialWatchKey}
+		returnFunc := s.updateCredentialStatusFunc(request, slcMetadata)
+		updateFuncs = append(updateFuncs, returnFunc)
+	}
+	returnValue, err := s.storage.db.Execute(ctx, func(ctx context.Context, tx storage.Tx) (any, error) {
+		batchResponse := BatchUpdateCredentialStatusResponse{
+			CredentialStatuses: make([]Status, 0, len(batchRequest.Requests)),
+		}
+		for i, updateFunc := range updateFuncs {
+			updateResp, err := updateFunc(ctx, tx)
+			if err != nil {
+				return nil, err
+			}
+			batchResponse.CredentialStatuses = append(batchResponse.CredentialStatuses, updateResp.(*UpdateCredentialStatusResponse).Status)
+			batchResponse.CredentialStatuses[i].ID = batchRequest.Requests[i].ID
+		}
+		return &batchResponse, nil
+	}, watchKeys)
+	if err != nil {
+		return nil, errors.Wrap(err, "execute")
+	}
+
+	batchResponse, ok := returnValue.(*BatchUpdateCredentialStatusResponse)
+	if !ok {
+		return nil, errors.New("casting to BatchUpdateCredentialStatusResponse")
+	}
+
+	return batchResponse, nil
+}
+
+func (s Service) statusListCredentialWatchKey(ctx context.Context, id string) (*storage.WatchKey, error) {
+	gotCred, err := s.storage.GetCredential(ctx, id)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading credential")
+	}
+
+	if gotCred.Credential.CredentialStatus == nil {
+		return nil, sdkutil.LoggingNewErrorf("credential %q has no credentialStatus field", gotCred.LocalCredentialID)
+	}
+
+	statusPurpose := gotCred.Credential.CredentialStatus.(map[string]any)["statusPurpose"].(string)
+	if len(statusPurpose) == 0 {
+		return nil, sdkutil.LoggingNewErrorf("status purpose could not be derived from credential status")
+	}
+
+	statusListCredential, err := s.storage.GetStatusListCredentialKeyData(ctx, gotCred.Issuer, gotCred.Schema, statussdk.StatusPurpose(statusPurpose))
+	if err != nil {
+		return nil, errors.Wrap(err, "getting status list watch key uuid data")
+	}
+
+	if statusListCredential == nil {
+		return nil, errors.Wrap(err, "status list credential should exist in order to update")
+	}
+
+	statusListCredentialWatchKey := s.storage.GetStatusListCredentialWatchKey(gotCred.Issuer, gotCred.Schema, statusPurpose)
+	return &statusListCredentialWatchKey, nil
 }

--- a/pkg/service/credential/service.go
+++ b/pkg/service/credential/service.go
@@ -705,11 +705,11 @@ func (s Service) statusListCredentialWatchKey(ctx context.Context, id string) (*
 		return nil, errors.Wrap(err, "reading credential")
 	}
 
-	if gotCred.Credential.CredentialStatus == nil {
+	if !gotCred.HasCredentialStatus() {
 		return nil, sdkutil.LoggingNewErrorf("credential %q has no credentialStatus field", gotCred.LocalCredentialID)
 	}
 
-	statusPurpose := gotCred.Credential.CredentialStatus.(map[string]any)["statusPurpose"].(string)
+	statusPurpose := gotCred.GetStatusPurpose()
 	if len(statusPurpose) == 0 {
 		return nil, sdkutil.LoggingNewErrorf("status purpose could not be derived from credential status")
 	}


### PR DESCRIPTION
# Overview
This PR adds a batch endpoint for updating statuses of credentials. It is the last PR that fixes #347

# Description
Added the `v1/credentials/status/batch` endpoint. See the swagger spec file for documentation on the request/response schemas.

# How Has This Been Tested?
Unit and integration tests. 
